### PR TITLE
[ENH] Moving test data to figshare

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,13 +9,13 @@ TRX_MINIMAL_INSTALL = False if TRX_MINIMAL_INSTALL is None else \
 
 if TRX_MINIMAL_INSTALL:
     SCRIPTS = None
-    REQUIRES = ['numpy>=1.20.*', 'nibabel>=3.*', 'gdown>=4.*',
+    REQUIRES = ['numpy>=1.20.*', 'nibabel>=3.*',
                 'pytest>=7.*', 'pytest-console-scripts>=0.*']
 else:
     SCRIPTS = glob.glob("scripts/*.py")
     REQUIRES = ['fury@git+https://github.com/frheault/fury.git@5059a529#egg=fury',
                 'dipy@git+https://github.com/frheault/dipy.git@4e192c5c6#egg=dipy',
-                'gdown>=4.*', 'pytest>=7.*', 'pytest-console-scripts>=0.*']
+                'pytest>=7.*', 'pytest-console-scripts>=0.*']
 
 setup(name='trx',
       packages=find_packages(),

--- a/trx/fetcher.py
+++ b/trx/fetcher.py
@@ -21,8 +21,8 @@ def get_testing_files_dict():
     """ Get dictionary linking zip file to their Figshare URL & MD5SUM """
     return {
         'DSI.zip': 
-            ('https://figshare.com/ndownloader/files/35596973',
-             'a984e4f5a37273063a713ee578901127')
+            ('https://figshare.com/ndownloader/files/35617193',
+             '7d7082f7f2e07cb39e2fef13107af169')
     }
 
 
@@ -72,7 +72,11 @@ def fetch_data(files_dict, keys=None):
 
         actual_md5 = md5sum(full_path)
         if expected_md5 != actual_md5:
-            raise ValueError(f'md5sum for {f} does not match.')
+            raise ValueError(
+                f'Md5sum for {f} does not match. '
+                'Please remove the file to download it again: ' +
+                full_path
+            )
 
         if f.endswith('.zip'):
             dst_dir = os.path.join(trx_home, f[:-4])


### PR DESCRIPTION
Here's a PR to update the `trx.fetcher` code to get data from Figshare, instead of Google Drive.

Solves #25 