### PR TITLE
Control tmpdir for files

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,17 @@ Or, to install from source:
     git clone https://github.com/tee-ar-ex/trx-python.git
     cd trx-python
     pip install .
+
+### Temporary Directory
+The TRX file format uses memmaps to limit RAM usage. When dealing with large files this means several gigabytes could be required on disk (instead of RAM). 
+
+By default, the temporary directory on Linux and MacOS is `/tmp` and on Windows it should be `C:\WINDOWS\Temp`.
+
+If you wish to change the directory add the following variable to your script or to your .bashrc or .bash_profile:
+`export TRX_TMPDIR=/WHERE/I/WANT/MY/TMP/DATA` (a)
+OR
+`export TRX_TMPDIR=use_working_dir` (b)
+
+The provided folder must already exists (a). `use_working_dir` will be the directory where the code is being executed from (b).
+
+The temporary folders should be automatically cleaned. But, if the code crash unexpectedly, make sure the folders are deleted.

--- a/scripts/tests/test_workflows.py
+++ b/scripts/tests/test_workflows.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 
 import os
-import tempfile
 
 import pytest
 import numpy as np
@@ -13,6 +12,7 @@ try:
 except ImportError:
     dipy_available = False
 
+from trx.io import get_trx_tmpdir
 from trx.trx_file_memmap import concatenate, load, save
 from trx.fetcher import (get_testing_files_dict,
                          fetch_data, get_home)
@@ -24,7 +24,7 @@ from trx.workflows import (convert_dsi_studio,
 
 # If they already exist, this only takes 5 seconds (check md5sum)
 fetch_data(get_testing_files_dict(), keys=['DSI.zip', 'trx_from_scratch.zip'])
-tmp_dir = tempfile.TemporaryDirectory()
+tmp_dir = get_trx_tmpdir()
 
 
 def test_help_option_convert_dsi(script_runner):

--- a/trx/io.py
+++ b/trx/io.py
@@ -17,7 +17,7 @@ from trx.utils import split_name_with_gz
 
 def get_trx_tmpdir():
     if os.getenv('TRX_TMPDIR') is not None:
-        if os.getenv('TRX_TMPDIR') == 'use_current_dir':
+        if os.getenv('TRX_TMPDIR') == 'use_working_dir':
             trx_tmp_dir = os.getcwd()
         else:
             trx_tmp_dir = os.getenv('TRX_TMPDIR')

--- a/trx/tests/test_io.py
+++ b/trx/tests/test_io.py
@@ -8,13 +8,13 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 from trx.trx_file_memmap import TrxFile
-from trx.io import load_wrapper, save_wrapper
+from trx.io import load_wrapper, save_wrapper, get_trx_tmpdir
 from trx.fetcher import (get_testing_files_dict,
                          fetch_data, get_home)
 
 
 fetch_data(get_testing_files_dict(), keys=['gold_standard.zip'])
-tmp_dir = tempfile.TemporaryDirectory()
+tmp_dir = get_trx_tmpdir()
 
 
 @pytest.mark.parametrize("path", [("gs.trx"), ("gs.trk"), ("gs.tck"),

--- a/trx/tests/test_memmap.py
+++ b/trx/tests/test_memmap.py
@@ -2,18 +2,17 @@
 # -*- coding: utf-8 -*-
 
 import os
-import tempfile
-from tempfile import mkdtemp
 
 import pytest
 import numpy as np
+from trx.io import get_trx_tmpdir
 import trx.trx_file_memmap as tmm
 from trx.fetcher import (get_testing_files_dict,
                          fetch_data, get_home)
 
 
 fetch_data(get_testing_files_dict(), keys=['memmap_test_data.zip'])
-tmp_dir = tempfile.TemporaryDirectory()
+tmp_dir = get_trx_tmpdir()
 
 
 @pytest.mark.parametrize(
@@ -121,19 +120,22 @@ def test__dichotomic_search(arr, l_bound, r_bound, expected):
 def test__create_memmap(basename, create, expected):
     if create:
         # Need to create array before evaluating
-        filename = os.path.join(mkdtemp(), basename)
-        fp = np.memmap(filename, dtype=np.int16, mode="w+", shape=(3, 4))
-        fp[:] = expected[:]
-        mmarr = tmm._create_memmap(filename=filename, shape=(3, 4),
-                                   dtype=np.int16)
-        assert np.array_equal(mmarr, expected)
+        with get_trx_tmpdir() as dirname:
+            filename = os.path.join(dirname, basename)
+            fp = np.memmap(filename, dtype=np.int16, mode="w+", shape=(3, 4))
+            fp[:] = expected[:]
+            mmarr = tmm._create_memmap(filename=filename, shape=(3, 4),
+                                       dtype=np.int16)
+            assert np.array_equal(mmarr, expected)
 
     else:
-        filename = os.path.join(mkdtemp(), basename)
-        mmarr = tmm._create_memmap(filename=filename, shape=(0,),
-                                   dtype=np.int16)
-        assert os.path.isfile(filename)
-        assert np.array_equal(mmarr, np.zeros(shape=(0,), dtype=np.float32))
+        with get_trx_tmpdir() as dirname:
+            filename = os.path.join(dirname, basename)
+            mmarr = tmm._create_memmap(filename=filename, shape=(0,),
+                                       dtype=np.int16)
+            assert os.path.isfile(filename)
+            assert np.array_equal(mmarr, np.zeros(
+                shape=(0,), dtype=np.float32))
 
 
 # need dpg test with missing keys

--- a/trx/trx_file_memmap.py
+++ b/trx/trx_file_memmap.py
@@ -6,7 +6,6 @@ import json
 import logging
 import os
 import shutil
-import tempfile
 from typing import Any, List, Tuple, Type, Union, Optional
 import zipfile
 
@@ -19,6 +18,7 @@ from nibabel.streamlines.trk import TrkFile
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
 
+from trx.io import get_trx_tmpdir
 from trx.utils import get_reference_info_wrapper
 
 
@@ -219,7 +219,7 @@ def load(input_obj: str, check_dpg: bool = True) -> Type["TrxFile"]:
                     break
         if was_compressed:
             with zipfile.ZipFile(input_obj, "r") as zf:
-                tmpdir = tempfile.TemporaryDirectory()
+                tmpdir = get_trx_tmpdir()
                 zf.extractall(tmpdir.name)
                 trx = load_from_directory(tmpdir.name)
                 trx._uncompressed_folder_handle = tmpdir
@@ -727,7 +727,7 @@ class TrxFile:
         Returns
             A deepcopied TrxFile of the current TrxFile
         """
-        tmp_dir = tempfile.TemporaryDirectory()
+        tmp_dir = get_trx_tmpdir()
         out_json = open(os.path.join(tmp_dir.name, "header.json"), "w")
         tmp_header = deepcopy(self.header)
 
@@ -905,7 +905,7 @@ class TrxFile:
             An empty TrxFile preallocated with a certain size
         """
         trx = TrxFile()
-        tmp_dir = tempfile.TemporaryDirectory()
+        tmp_dir = get_trx_tmpdir()
         logging.info("Temporary folder for memmaps: {}".format(tmp_dir.name))
 
         trx.header["NB_VERTICES"] = nb_vertices
@@ -1429,7 +1429,7 @@ class TrxFile:
         trx.data_per_vertex = sft.data_per_point
 
         # For safety and for RAM, convert the whole object to memmaps
-        tmpdir = tempfile.TemporaryDirectory()
+        tmpdir = get_trx_tmpdir()
         save(trx, tmpdir.name)
         trx = load_from_directory(tmpdir.name)
         trx._uncompressed_folder_handle = tmpdir
@@ -1473,7 +1473,7 @@ class TrxFile:
         trx.data_per_vertex = tractogram.data_per_point
 
         # For safety and for RAM, convert the whole object to memmaps
-        tmpdir = tempfile.TemporaryDirectory()
+        tmpdir = get_trx_tmpdir()
         save(trx, tmpdir.name)
         trx = load_from_directory(tmpdir.name)
         trx._uncompressed_folder_handle = tmpdir

--- a/trx/workflows.py
+++ b/trx/workflows.py
@@ -7,7 +7,6 @@ import gzip
 import json
 import logging
 import os
-import tempfile
 
 import nibabel as nib
 from nibabel.streamlines.array_sequence import ArraySequence
@@ -21,7 +20,7 @@ try:
 except ImportError:
     dipy_available = False
 
-from trx.io import load_wrapper, load_sft_with_reference, save_wrapper
+from trx.io import get_trx_tmpdir, load_wrapper, load_sft_with_reference, save_wrapper
 from trx.streamlines_ops import perform_streamlines_operation, intersection
 from trx.trx_file_memmap import _compute_lengths, load, save, TrxFile
 from trx.viz import display
@@ -287,7 +286,7 @@ def generate_trx_from_scratch(reference, out_tractogram, positions_csv=False,
                               space_str='rasmm', origin_str='nifti',
                               verify_invalid=True, dpv=[], dps=[],
                               groups=[], dpg=[]):
-    with tempfile.TemporaryDirectory() as tmpdirname:
+    with get_trx_tmpdir() as tmpdirname:
         if positions_csv:
             with open(positions_csv, newline='') as f:
                 reader = csv.reader(f)
@@ -303,7 +302,6 @@ def generate_trx_from_scratch(reference, out_tractogram, positions_csv=False,
             streamlines._data = positions
             streamlines._offsets = deepcopy(offsets)
             streamlines._lengths = lengths
-            print(len(offsets), len(lengths), len(positions))
 
         if space_str.lower() != 'rasmm' or origin_str.lower() != 'nifti' or \
                 verify_invalid:
@@ -331,7 +329,6 @@ def generate_trx_from_scratch(reference, out_tractogram, positions_csv=False,
             "NB_VERTICES": len(streamlines._data),
             "NB_STREAMLINES": len(streamlines)-1,
         }
-        print(header)
 
         if header['NB_STREAMLINES'] <= 1:
             raise IOError('To use this script, you need at least 2'


### PR DESCRIPTION
This PR is related to Issue #40 

This requires PR #37 to be merged first, I needed the new module trx.io to exist to test some things.

Simply replaces all calls to `tempfile.TemporaryDirectory` by a new function below:
```
def get_trx_tmpdir():
    if os.getenv('TRX_TMPDIR') is not None:
        if os.getenv('TRX_TMPDIR') == 'use_working_dir':
            trx_tmp_dir = os.getcwd()
        else:
            trx_tmp_dir = os.getenv('TRX_TMPDIR')
    else:
        trx_tmp_dir = tempfile.gettempdir()

    return tempfile.TemporaryDirectory(dir=trx_tmp_dir, prefix='trx_')
```

3 options:

1. Same behavior (to /tmp)
2. Specify a new folder
3. Use the working directory

I will add a check if the folder does not exist. But should I create it myself?