### PR TITLE
(WIP) TRX integration to Scilpy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-
+trx/version.py
 .DS_Store
 *_version.py
 
@@ -51,7 +51,7 @@ htmlcov/
 nosetests.xml
 coverage.xml
 *.cover
-*.py,cover
+*.py, cover
 .hypothesis/
 .pytest_cache/
 
@@ -93,7 +93,7 @@ ipython_config.py
 #   However, in case of collaboration, if having platform-specific dependencies or dependencies
 #   having no cross-platform support, pipenv may install dependencies that don't work, or not
 #   install all needed dependencies.
-#Pipfile.lock
+# Pipfile.lock
 
 # PEP 582; used by e.g. github.com/David-OConnor/pyflow
 __pypackages__/

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Or, to install from source:
 If you wish to use all the scripts and run the test you will need to install Dipy
 
     pip install cython packaging
-    pip install dipy@git+https://git@github.com/scilus/hot_dipy@4aad997#egg=dipy
+    pip install dipy@git+https://git@github.com/frheault/dipy@ba3ce0c59#egg=dipy
 
 ### Temporary Directory
 The TRX file format uses memmaps to limit RAM usage. When dealing with large files this means several gigabytes could be required on disk (instead of RAM). 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ Or, to install from source:
     cd trx-python
     pip install .
 
+### Install Dipy for integration
+If you wish to use all the scripts and run the test you will need to install Dipy
+
+    pip install cython
+    pip install dipy@git+https://git@github.com/dipy/dipy@6c5a6f6#egg=dipy
+
 ### Temporary Directory
 The TRX file format uses memmaps to limit RAM usage. When dealing with large files this means several gigabytes could be required on disk (instead of RAM). 
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Or, to install from source:
 ### Install Dipy for integration
 If you wish to use all the scripts and run the test you will need to install Dipy
 
-    pip install cython
-    pip install dipy@git+https://git@github.com/dipy/dipy@6c5a6f6#egg=dipy
+    pip install cython packaging
+    pip install dipy@git+https://git@github.com/scilus/hot_dipy@4aad997#egg=dipy
 
 ### Temporary Directory
 The TRX file format uses memmaps to limit RAM usage. When dealing with large files this means several gigabytes could be required on disk (instead of RAM). 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -63,9 +63,6 @@ html_logo = "../_static/trx_logo.png"
 
 
 html_theme_options = {
-    "logo": {
-        "text": "TRX Python",
-    },
     "icon_links": [
         {
             # Label for this link

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 42.0", "wheel", "setuptools_scm[toml] >= 3.4", "setuptools_scm_git_archive"]
+requires = ["setuptools >= 42.0", "wheel", "setuptools_scm[toml] >= 3.4", "setuptools_scm_git_archive", "numpy", "cython"]
 build-backend = "setuptools.build_meta:__legacy__"
 
 [tool.setuptools_scm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 42.0", "wheel", "setuptools_scm[toml] >= 3.4", "setuptools_scm_git_archive", "numpy", "cython"]
+requires = ["setuptools >= 42.0", "wheel", "setuptools_scm[toml] >= 3.4", "setuptools_scm_git_archive", "Cython", "numpy"]
 build-backend = "setuptools.build_meta:__legacy__"
 
 [tool.setuptools_scm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 42.0", "wheel", "setuptools_scm[toml] >= 3.4", "setuptools_scm_git_archive", "Cython", "numpy"]
+requires = ["setuptools >= 42.0", "wheel", "setuptools_scm[toml] >= 3.4", "setuptools_scm_git_archive"]
 build-backend = "setuptools.build_meta:__legacy__"
 
 [tool.setuptools_scm]

--- a/scripts/tests/test_workflows.py
+++ b/scripts/tests/test_workflows.py
@@ -194,6 +194,8 @@ def test_execution_generate_trx_from_scratch():
     exp_trx = tmm.load(expected_trx)
     gen_trx = tmm.load('generated.trx')
 
+    assert DeepDiff(exp_trx.get_dtype_dict(), gen_trx.get_dtype_dict()) == {}
+
     assert_allclose(exp_trx.streamlines._data, gen_trx.streamlines._data,
                     atol=0.1, rtol=0.1)
     assert_equal(exp_trx.streamlines._offsets, gen_trx.streamlines._offsets)
@@ -223,7 +225,6 @@ def test_execution_concatenate_validate_trx():
     trx2 = tmm.load(os.path.join(get_home(), 'gold_standard',
                                  'gs.trx'))
     trx2.streamlines._data += + 0.001
-
     trx = tmm.concatenate([trx1, trx2], preallocation=False)
 
     # Right size
@@ -253,10 +254,13 @@ def test_execution_concatenate_validate_trx():
     validate_tractogram('concat.trx', None, 'valid.trx',
                         remove_identical_streamlines=True,
                         precision=0)
-    trx = tmm.load('valid.trx')
+    trx_val = tmm.load('valid.trx')
+
+    # Right dtype
+    assert DeepDiff(trx.get_dtype_dict(), trx_val.get_dtype_dict()) == {}
 
     # Right size
-    assert_equal(len(trx.streamlines), len(trx1.streamlines))
+    assert_equal(len(trx1.streamlines), len(trx_val.streamlines))
 
 
 def test_execution_manipulate_trx_datatype():

--- a/scripts/tests/test_workflows.py
+++ b/scripts/tests/test_workflows.py
@@ -224,7 +224,7 @@ def test_execution_concatenate_validate_trx():
                                  'gs.trx'))
     trx2 = tmm.load(os.path.join(get_home(), 'gold_standard',
                                  'gs.trx'))
-    trx2.streamlines._data += + 0.001
+    # trx2.streamlines._data += 0.001
     trx = tmm.concatenate([trx1, trx2], preallocation=False)
 
     # Right size

--- a/scripts/tff_manipulate_datatype.py
+++ b/scripts/tff_manipulate_datatype.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+Manipulate a TRX file internal array to change their data type.
+
+Each instance of --dps, --dpv, --groups require 2 arguments (FILE, DTYPE).
+--dpg requires 3 arguments (GROUP, FILE, DTYPE).
+The choice of DTYPE are:
+    - (u)int8, (u)int16, (u)int32, (u)int64
+    - float16, float32, float64
+    - bool
+
+Example command:
+tff_manipulate_datatype.py input.trx output.trx \
+    --position float16 --offsets uint64 \
+    --dpv color_x uint8 --dpv color_y uint8 --dpv color_z uint8 \
+    --dpv fa float16 --dps algo uint8 --dps clusters_QB uint16 \
+    --dps commit_colors uint8 --dps commit_weights float16 \
+    --group CC uint64 --dpg CC mean_fa float64
+"""
+
+import argparse
+import os
+
+import numpy as np
+from trx.workflows import manipulate_trx_datatype
+
+
+def _build_arg_parser():
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter)
+    p.add_argument('in_tractogram',
+                   help='Input TRX file.')
+    p.add_argument('out_tractogram',
+                   help='Output filename. Format must be one of\n'
+                        'trk, tck, vtk, fib, dpy, trx.')
+
+    p2 = p.add_argument_group(title='Data type options')
+    p2.add_argument('--positions_dtype',
+                    choices=['float16', 'float32', 'float64'],
+                    help='Specify the datatype for positions for trx. '
+                         '[%(choices)s]')
+    p2.add_argument('--offsets_dtype',
+                    choices=['uint32', 'uint64'],
+                    help='Specify the datatype for offsets for trx. '
+                         '[%(choices)s]')
+
+    p3 = p.add_argument_group(title='Streamlines metadata options')
+    p3.add_argument('--dpv', metavar=('NAME', 'DTYPE'), nargs=2,
+                    action='append',
+                    help='Specify the datatype for a specific data_per_vertex.')
+    p3.add_argument('--dps', metavar=('NAME', 'DTYPE'), nargs=2,
+                    action='append',
+                    help='Specify the datatype for a specific data_per_streamline.')
+    p3.add_argument('--groups', metavar=('NAME', 'DTYPE'), nargs=2,
+                    action='append',
+                    help='Specify the datatype for a specific group.')
+    p3.add_argument('--dpg', metavar=('GROUP', 'NAME', 'DTYPE'), nargs=3,
+                    action='append',
+                    help='Specify the datatype for a specific data_per_group.')
+    p.add_argument('-f', dest='overwrite', action='store_true',
+                   help='Force overwriting of the output files.')
+
+    return p
+
+
+def main():
+    parser = _build_arg_parser()
+    args = parser.parse_args()
+
+    if os.path.isfile(args.out_tractogram) and not args.overwrite:
+        raise IOError('{} already exists, use -f to overwrite.'.format(
+            args.out_tractogram))
+
+    dtype_dict = {}
+    if args.positions_dtype:
+        dtype_dict['positions'] = np.dtype(args.positions_dtype)
+    if args.offsets_dtype:
+        dtype_dict['offsets'] = np.dtype(args.offsets_dtype)
+    
+    if args.dpv:
+        dtype_dict['dpv'] = {}
+        for name, dtype in args.dpv:
+            dtype_dict['dpv'][name] = np.dtype(dtype)
+    if args.dps:
+        dtype_dict['dps'] = {}
+        for name, dtype in args.dps:
+            dtype_dict['dps'][name] = np.dtype(dtype)
+    if args.groups:
+        dtype_dict['groups'] = {}
+        for name, dtype in args.groups:
+            dtype_dict['groups'][name] = np.dtype(dtype)
+    if args.dpg:
+        dtype_dict['dpg'] = {}
+        for group, name, dtype in args.dpg:
+            dtype_dict['dpg'][group] = {name: np.dtype(dtype)}
+    print(dtype_dict)
+    manipulate_trx_datatype(args.in_tractogram, args.out_tractogram, dtype_dict)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tff_manipulate_datatype.py
+++ b/scripts/tff_manipulate_datatype.py
@@ -95,7 +95,7 @@ def main():
         dtype_dict['dpg'] = {}
         for group, name, dtype in args.dpg:
             dtype_dict['dpg'][group] = {name: np.dtype(dtype)}
-    print(dtype_dict)
+
     manipulate_trx_datatype(args.in_tractogram, args.out_tractogram, dtype_dict)
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ test =
     pytest >= 7
     pytest-console-scripts >= 0
     fury
-    dipy
+    dipy @ git+https://git@github.com/dipy/dipy@v1.6#egg=dipy
 
 all =
     %(doc)s

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,8 @@ test =
     pytest >= 7
     pytest-console-scripts >= 0
     fury
-    dipy@git+https://git@github.com/frheault/dipy@bf49fed#egg=dipy
+    cython
+    dipy@git+https://git@github.com/frheault/dipy@2f21a141c#egg=dipy
 
 all =
     %(doc)s

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ test =
     pytest-console-scripts >= 0
     fury
     cython
-    dipy@git+https://git@github.com/dipy/dipy@ba3ce0c59#egg=dipy
+    dipy@git+https://git@github.com/frheault/dipy@ba3ce0c59#egg=dipy
 
 all =
     %(doc)s

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ include_package_data = True
 python_requires = >=3.7
 setup_requires =
     packaging >= 19.0
+    cython >= 0.29
 install_requires =
     setuptools_scm
     deepdiff

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ test =
     pytest-console-scripts >= 0
     fury
     cython
-    dipy@git+https://git@github.com/frheault/dipy@ba3ce0c59#egg=dipy
+    dipy@git+https://git@github.com/frheault/dipy@2f21a141c#egg=dipy
 
 all =
     %(doc)s

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,8 +41,7 @@ test =
     pytest-console-scripts >= 0
     fury
     cython
-    packaging
-    dipy@git+https://git@github.com/dipy/dipy@6c5a6f6#egg=dipy
+    dipy@git+https://git@github.com/scilus/hot_dipy@4aad997#egg=dipy
 
 all =
     %(doc)s

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,18 +26,18 @@ setup_requires =
   packaging >=19.0
 install_requires =
   setuptools_scm
-  nibabel >= 3.*
+  nibabel >= 3
 
 [options.extras_require]
-doc = sphinx<=6.*
+doc = sphinx <= 6
       pydata-sphinx-theme
       sphinx-autoapi
       numpydoc
 
 test =
       flake8
-      pytest>=7.*
-      pytest-console-scripts>=0.*
+      pytest >= 7
+      pytest-console-scripts>=0
       fury
       dipy
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,7 @@ test =
     pytest-console-scripts >= 0
     fury
     cython
+    packaging
     dipy@git+https://git@github.com/dipy/dipy@6c5a6f6#egg=dipy
 
 all =

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ test =
     pytest-console-scripts >= 0
     fury
     cython
-    dipy@git+https://git@github.com/scilus/hot_dipy@4aad997#egg=dipy
+    dipy@git+https://git@github.com/dipy/dipy@ba3ce0c59#egg=dipy
 
 all =
     %(doc)s

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,18 +1,18 @@
 [metadata]
 name = trx-python
-url = https://github.com/tee-ar-ex/trx-python
+url = https: // github.com/tee-ar-ex/trx-python
 classifiers =
-    Development Status :: 3 - Alpha
-    Environment :: Console
-    Intended Audience :: Science/Research
-    License :: OSI Approved :: BSD License
-    Operating System :: OS Independent
-    Programming Language :: Python
-    Topic :: Scientific/Engineering
+    Development Status: : 3 - Alpha
+    Environment: : Console
+    Intended Audience: : Science/Research
+    License:: OSI Approved : : BSD License
+    Operating System: : OS Independent
+    Programming Language: : Python
+    Topic: : Scientific/Engineering
 
 license = BSD License
 description = Experiments with new file format for tractography
-long_description = file:README.md
+long_description = file: README.md
 long_description_content_type = text/markdown
 platforms = OS Independent
 
@@ -23,23 +23,24 @@ include_package_data = True
 [options]
 python_requires = >=3.7
 setup_requires =
-  packaging >=19.0
+    packaging >= 19.0
 install_requires =
-  setuptools_scm
-  nibabel >= 3
+    setuptools_scm
+    deepdiff
+    nibabel >= 3
 
 [options.extras_require]
 doc = sphinx <= 6
-      pydata-sphinx-theme
-      sphinx-autoapi
-      numpydoc
+    pydata-sphinx-theme
+    sphinx-autoapi
+    numpydoc
 
 test =
-      flake8
-      pytest >= 7
-      pytest-console-scripts>=0
-      fury
-      dipy
+    flake8
+    pytest >= 7
+    pytest-console-scripts >= 0
+    fury
+    dipy
 
 all =
     %(doc)s

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,8 +40,7 @@ test =
     pytest >= 7
     pytest-console-scripts >= 0
     fury
-    cython
-    dipy@git+https://git@github.com/frheault/dipy@2f21a141c#egg=dipy
+    dipy@git+https://git@github.com/frheault/dipy@bf49fed#egg=dipy
 
 all =
     %(doc)s

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,8 @@ test =
     pytest >= 7
     pytest-console-scripts >= 0
     fury
-    dipy @ git+https://git@github.com/dipy/dipy@v1.6#egg=dipy
+    cython
+    dipy@git+https://git@github.com/dipy/dipy@6c5a6f6#egg=dipy
 
 all =
     %(doc)s

--- a/trx/io.py
+++ b/trx/io.py
@@ -6,8 +6,7 @@ import logging
 import tempfile
 
 try:
-    from dipy.io.stateful_tractogram import StatefulTractogram
-    from dipy.io.streamline import load_tractogram, save_tractogram
+    import dipy
     dipy_available = True
 except ImportError:
     dipy_available = False
@@ -33,6 +32,8 @@ def load_sft_with_reference(filepath, reference=None,
         logging.error('Dipy library is missing, cannot use functions related '
                       'to the StatefulTractogram.')
         return None
+    from dipy.io.streamline import load_tractogram
+
     # Force the usage of --reference for all file formats without an header
     _, ext = os.path.splitext(filepath)
     if ext == '.trk':
@@ -69,7 +70,14 @@ def load(tractogram_filename, reference):
 
 
 def save(tractogram_obj, tractogram_filename, bbox_valid_check=False):
+    if not dipy_available:
+        logging.error('Dipy library is missing, cannot use functions related '
+                    'to the StatefulTractogram.')
+        return None
+    from dipy.io.stateful_tractogram import StatefulTractogram
+    from dipy.io.streamline import save_tractogram
     import trx.trx_file_memmap as tmm
+
     out_ext = split_name_with_gz(tractogram_filename)[1]
 
     if out_ext != '.trx':

--- a/trx/io.py
+++ b/trx/io.py
@@ -68,7 +68,7 @@ def load(tractogram_filename, reference):
     return tractogram_obj
 
 
-def save(tractogram_obj, tractogram_filename):
+def save(tractogram_obj, tractogram_filename, bbox_valid_check=False):
     import trx.trx_file_memmap as tmm
     out_ext = split_name_with_gz(tractogram_filename)[1]
 
@@ -76,7 +76,7 @@ def save(tractogram_obj, tractogram_filename):
         if not isinstance(tractogram_obj, StatefulTractogram):
             tractogram_obj = tractogram_obj.to_sft()
         save_tractogram(tractogram_obj, tractogram_filename,
-                        bbox_valid_check=False)
+                        bbox_valid_check=bbox_valid_check)
     else:
         if not isinstance(tractogram_obj, tmm.TrxFile):
             tractogram_obj = tmm.TrxFile.from_sft(tractogram_obj)

--- a/trx/tests/test_io.py
+++ b/trx/tests/test_io.py
@@ -6,6 +6,13 @@ import os
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose
+
+try:
+    import dipy
+    dipy_available = True
+except ImportError:
+    dipy_available = False
+
 from trx.trx_file_memmap import TrxFile
 from trx.io import load, save, get_trx_tmpdir
 from trx.fetcher import (get_testing_files_dict,
@@ -18,6 +25,7 @@ tmp_dir = get_trx_tmpdir()
 
 @pytest.mark.parametrize("path", [("gs.trx"), ("gs.trk"), ("gs.tck"),
                                   ("gs.vtk")])
+@pytest.mark.skipif(not dipy_available, reason="Dipy is not installed")
 def test_load_vox(path):
     dir = os.path.join(get_home(), 'gold_standard')
     path = os.path.join(dir, path)
@@ -33,6 +41,7 @@ def test_load_vox(path):
 
 @pytest.mark.parametrize("path", [("gs.trx"), ("gs.trk"), ("gs.tck"),
                                   ("gs.vtk")])
+@pytest.mark.skipif(not dipy_available, reason="Dipy is not installed")
 def test_load_voxmm(path):
     dir = os.path.join(get_home(), 'gold_standard')
     path = os.path.join(dir, path)
@@ -46,7 +55,8 @@ def test_load_voxmm(path):
     assert_allclose(sft.streamlines._data, coord, rtol=1e-04, atol=1e-06)
 
 
-@pytest.mark.parametrize("path", [("gs.trk"), ("gs.trx"), ("gs_fldr.trx"), ])
+@pytest.mark.parametrize("path", [("gs.trk"), ("gs.trx"), ("gs_fldr.trx")])
+@pytest.mark.skipif(not dipy_available, reason="Dipy is not installed")
 def test_multi_load_save_rasmm(path):
     dir = os.path.join(get_home(), 'gold_standard')
     basename, ext = os.path.splitext(path)

--- a/trx/tests/test_memmap.py
+++ b/trx/tests/test_memmap.py
@@ -8,6 +8,12 @@ from nibabel.streamlines import LazyTractogram
 import numpy as np
 import pytest
 
+try:
+    import dipy
+    dipy_available = True
+except ImportError:
+    dipy_available = False
+
 from trx.io import get_trx_tmpdir
 import trx.trx_file_memmap as tmm
 from trx.fetcher import (get_testing_files_dict,
@@ -217,6 +223,7 @@ def test_append(path, buffer):
 
 
 @pytest.mark.parametrize("path, buffer", [("small.trx", 10000)])
+@pytest.mark.skipif(not dipy_available, reason="Dipy is not installed")
 def test_append_StatefulTractogram(path, buffer):
     path = os.path.join(get_home(), 'memmap_test_data', path)
     trx = tmm.load(path)

--- a/trx/tests/test_memmap.py
+++ b/trx/tests/test_memmap.py
@@ -249,7 +249,7 @@ def test_append_Tractogram(path, buffer):
                                                 ("small.trx", 0, 0),
                                                 ("small.trx", 25000, 10000)])
 def test_from_lazy_tractogram(path, size, buffer):
-    rng = np.random.RandomState(1776)
+    _ = np.random.RandomState(1776)
     streamlines = []
     fa = []
     commit_weights = []
@@ -265,11 +265,6 @@ def test_from_lazy_tractogram(path, size, buffer):
         clusters_QB.append(
             data_for_streamline['mean_torsion'].astype(np.uint16))
 
-    data_per_point = {'fa': [e for e in fa]}
-    data_per_streamline = {
-        'commit_weights': [e for e in commit_weights],
-        'clusters_QB': [e for e in clusters_QB]}
-
     def streamlines_func(): return (e for e in streamlines)
     data_per_point_func = {'fa': lambda: (e for e in fa)}
     data_per_streamline_func = {
@@ -281,10 +276,16 @@ def test_from_lazy_tractogram(path, size, buffer):
                          data_per_point_func,
                          affine_to_rasmm=np.eye(4))
 
+    dtype_dict = {'positions': np.float32, 'offsets': np.uint32,
+                  'dpv': {'fa': np.float16},
+                  'dps': {'commit_weights': np.float32,
+                          'clusters_QB': np.uint16}}
     path = os.path.join(get_home(), 'memmap_test_data', path)
     trx = tmm.TrxFile.from_lazy_tractogram(obj, reference=path,
                                            extra_buffer=buffer,
-                                           chunk_size=1000)
+                                           chunk_size=1000,
+                                           dtype_dict=dtype_dict)
+
     assert len(trx) == len(gen_range)
 
 

--- a/trx/trx_file_memmap.py
+++ b/trx/trx_file_memmap.py
@@ -1279,7 +1279,7 @@ class TrxFile:
         self.close()
         self.__dict__ = trx.__dict__
 
-    def get_dtype_dict(self) -> dict[str, np.dtype]:
+    def get_dtype_dict(self):
         """Get the dtype dictionary for the TrxFile
 
         Returns

--- a/trx/trx_file_memmap.py
+++ b/trx/trx_file_memmap.py
@@ -1289,12 +1289,21 @@ class TrxFile:
         """
         dtype_dict = {"positions": self.streamlines._data.dtype,
                       "offsets": self.streamlines._offsets.dtype,
-                      "dpv": {}, "dps": {}, "dpg": {}}
+                      "dpv": {}, "dps": {}, "dpg": {}, "groups": {}}
 
         for key in self.data_per_vertex.keys():
             dtype_dict['dpv'][key] = self.data_per_vertex[key]._data.dtype
         for key in self.data_per_streamline.keys():
             dtype_dict['dps'][key] = self.data_per_streamline[key].dtype
+
+        for group_key in self.data_per_group.keys():
+            dtype_dict['groups'][group_key] = self.groups[group_key].dtype
+
+        for group_key in self.data_per_group.keys():
+            dtype_dict['dpg'][group_key] = {}
+            for dpg_key in self.data_per_group[group_key].keys():
+                dtype_dict['dpg'][group_key][dpg_key] = \
+                    self.data_per_group[group_key][dpg_key].dtype
 
         return dtype_dict
 

--- a/trx/trx_file_memmap.py
+++ b/trx/trx_file_memmap.py
@@ -17,7 +17,6 @@ from nibabel.streamlines.array_sequence import ArraySequence
 from nibabel.streamlines.trk import TrkFile
 from nibabel.streamlines.tractogram import Tractogram, LazyTractogram
 import numpy as np
-from numpy.typing import ArrayLike, NDArray
 
 from trx.io import get_trx_tmpdir
 from trx.utils import (get_reference_info_wrapper,
@@ -31,17 +30,17 @@ except:
     dipy_available = False
 
 
-def _append_last_offsets(nib_offsets: NDArray, nb_vertices: int) -> NDArray:
+def _append_last_offsets(nib_offsets: np.ndarray, nb_vertices: int) -> np.ndarray:
     """Appends the last element of offsets from header information
 
     Keyword arguments:
-        nib_offsets -- NDArray
+        nib_offsets -- np.ndarray
             Array of offsets with the last element being the start of the last
             streamline (nibabel convention)
         nb_vertices -- int
             Total number of vertices in the streamlines
     Returns:
-        Offsets -- NDArray (VTK convention)
+        Offsets -- np.ndarray (VTK convention)
     """
     def is_sorted(a): return np.all(a[:-1] <= a[1:])
     if not is_sorted(nib_offsets):
@@ -49,7 +48,7 @@ def _append_last_offsets(nib_offsets: NDArray, nb_vertices: int) -> NDArray:
     return np.append(nib_offsets, nb_vertices).astype(nib_offsets.dtype)
 
 
-def _generate_filename_from_data(arr: ArrayLike, filename: str) -> str:
+def _generate_filename_from_data(arr: np.ndarray, filename: str) -> str:
     """Determines the data type from array data and generates the appropriate
     filename
 
@@ -105,14 +104,14 @@ def _split_ext_with_dimensionality(filename: str) -> Tuple[str, int, str]:
     return basename, int(dim), ext
 
 
-def _compute_lengths(offsets: NDArray) -> NDArray:
+def _compute_lengths(offsets: np.ndarray) -> np.ndarray:
     """Compute lengths from offsets
 
     Keyword arguments:
-        offsets -- An NDArray of offsets
+        offsets -- An np.ndarray of offsets
 
     Returns:
-        lengths -- An NDArray of lengths
+        lengths -- An np.ndarray of lengths
     """
     if len(offsets) > 0:
         last_elem_pos = _dichotomic_search(offsets)
@@ -144,12 +143,12 @@ def _is_dtype_valid(ext: str) -> bool:
 
 
 def _dichotomic_search(
-    x: NDArray, l_bound: Optional[int] = None, r_bound: Optional[int] = None
+    x: np.ndarray, l_bound: Optional[int] = None, r_bound: Optional[int] = None
 ) -> int:
     """Find where data of a contiguous array is actually ending
 
     Keyword arguments:
-        x -- NDArray of values
+        x -- np.ndarray of values
         l_bound -- lower bound index for search
         r_bound -- upper bound index for search
     Returns:
@@ -177,19 +176,19 @@ def _create_memmap(
     dtype: np.dtype = np.float32,
     offset: int = 0,
     order: str = "C",
-) -> NDArray:
+) -> np.ndarray:
     """Wrapper to support empty array as memmaps
 
     Keyword arguments:
         filename -- filename where the empty memmap should be created
         mode -- file open mode (see: np.memmap for options)
-        shape -- shape of memmapped NDArray
-        dtype -- datatype of memmapped NDArray
+        shape -- shape of memmapped np.ndarray
+        dtype -- datatype of memmapped np.ndarray
         offset -- offset of the data within the file
         order -- data representation on disk (C or Fortran)
 
     Returns:
-        mmapped NDArray or a zero-filled Numpy array if array has a shape of 0
+        mmapped np.ndarray or a zero-filled Numpy array if array has a shape of 0
             in the first dimension
     """
     if np.dtype(dtype) == bool:
@@ -1362,7 +1361,7 @@ class TrxFile:
         return self.select(self.groups[key], keep_group=keep_group, copy_safe=copy_safe)
 
     def select(
-        self, indices: ArrayLike, keep_group: bool = True, copy_safe: bool = False
+        self, indices: np.ndarray, keep_group: bool = True, copy_safe: bool = False
     ) -> Type["TrxFile"]:
         """Get a subset of items, always vertices to the same memmaps
 

--- a/trx/trx_file_memmap.py
+++ b/trx/trx_file_memmap.py
@@ -196,7 +196,8 @@ def _create_memmap(
 
     if shape[0]:
         return np.memmap(
-            filename, mode=mode, offset=offset, shape=shape, dtype=dtype, order=order
+            filename, mode=mode, offset=offset, shape=shape, dtype=dtype,
+            order=order
         )
     else:
         if not os.path.isfile(filename):
@@ -215,7 +216,7 @@ def load(input_obj: str, check_dpg: bool = True) -> Type["TrxFile"]:
     Returns:
         TrxFile object representing the read data
     """
-    # TODO Check if 0 streamlines, if yes then 0 vertices is expected (vice-versa)
+    # TODO Check if 0 streamlines, then 0 vertices is expected (vice-versa)
     # TODO 4x4 affine matrices should contains values (no all-zeros)
     # TODO 3x1 dimensions array should contains values at each position (int)
     if os.path.isfile(input_obj):
@@ -232,7 +233,8 @@ def load(input_obj: str, check_dpg: bool = True) -> Type["TrxFile"]:
                 trx = load_from_directory(tmpdir.name)
                 trx._uncompressed_folder_handle = tmpdir
                 logging.info(
-                    "File was compressed, call the close() " "function before exiting."
+                    "File was compressed, call the close() " "function before"
+                    "exiting."
                 )
         else:
             trx = load_from_zip(input_obj)
@@ -254,7 +256,8 @@ def load(input_obj: str, check_dpg: bool = True) -> Type["TrxFile"]:
 
 
 def load_from_zip(filename: str) -> Type["TrxFile"]:
-    """Load a TrxFile from a single zipfile. Note: does not work with compressed zipfiles
+    """Load a TrxFile from a single zipfile. Note: does not work with
+    compressed zipfiles
 
     Keyword arguments:
     filename -- path of the zipped TrxFile
@@ -316,9 +319,8 @@ def load_from_directory(directory: str) -> Type["TrxFile"]:
     directory = os.path.abspath(directory)
     with open(os.path.join(directory, "header.json")) as header:
         header = json.load(header)
-        header["VOXEL_TO_RASMM"] = np.reshape(header["VOXEL_TO_RASMM"], (4, 4)).astype(
-            np.float32
-        )
+        header["VOXEL_TO_RASMM"] = np.reshape(header["VOXEL_TO_RASMM"],
+                                              (4, 4)).astype(np.float32)
         header["DIMENSIONS"] = np.array(header["DIMENSIONS"], dtype=np.uint16)
     files_pointer_size = {}
     for root, dirs, files in os.walk(directory):
@@ -346,7 +348,8 @@ def load_from_directory(directory: str) -> Type["TrxFile"]:
             else:
                 raise ValueError("Wrong size or datatype")
 
-    return TrxFile._create_trx_from_pointer(header, files_pointer_size, root=directory)
+    return TrxFile._create_trx_from_pointer(header, files_pointer_size,
+                                            root=directory)
 
 
 def concatenate(
@@ -480,7 +483,8 @@ def concatenate(
             nb_vertices += curr_pts_len
 
         new_trx = TrxFile(
-            nb_vertices=nb_vertices, nb_streamlines=nb_streamlines, init_as=ref_trx
+            nb_vertices=nb_vertices, nb_streamlines=nb_streamlines,
+            init_as=ref_trx
         )
         if delete_dps:
             new_trx.data_per_streamline = {}
@@ -510,8 +514,8 @@ def concatenate(
             count = 0
             for curr_trx in trx_list:
                 curr_len = len(curr_trx.groups[group_key])
-                new_trx.groups[group_key][pos: pos +
-                                          curr_len] = curr_trx.groups[group_key] + count
+                new_trx.groups[group_key][pos: pos + curr_len] = \
+                    curr_trx.groups[group_key] + count
                 pos += curr_len
                 count += curr_trx.header["NB_STREAMLINES"]
 
@@ -854,10 +858,12 @@ class TrxFile:
             trx -- TrxFile to copy data from
             strs_start -- The start index of the streamline
             pts_start -- The start index of the point
-            nb_strs_to_copy -- The number of streamlines to copy. If not set will copy all
+            nb_strs_to_copy -- The number of streamlines to copy. If not set
+                                will copy all
 
         Returns
-            A tuple representing the end of the copied streamlines and end of copied points
+            A tuple representing the end of the copied streamlines and end of
+                copied points
         """
         if nb_strs_to_copy is None:
             curr_strs_len, curr_pts_len = trx._get_real_len()
@@ -873,15 +879,12 @@ class TrxFile:
             return strs_start, pts_start
 
         # Mandatory arrays
-        self.streamlines._data[pts_start:pts_end] = trx.streamlines._data[
-            0:curr_pts_len
-        ]
-        self.streamlines._offsets[strs_start:strs_end] = (
-            trx.streamlines._offsets[0:curr_strs_len] + pts_start
-        )
-        self.streamlines._lengths[strs_start:strs_end] = trx.streamlines._lengths[
-            0:curr_strs_len
-        ]
+        self.streamlines._data[pts_start:pts_end] = \
+            trx.streamlines._data[0:curr_pts_len]
+        self.streamlines._offsets[strs_start:strs_end] = \
+            (trx.streamlines._offsets[0:curr_strs_len] + pts_start)
+        self.streamlines._lengths[strs_start:strs_end] = \
+            trx.streamlines._lengths[0:curr_strs_len]
 
         # Optional fixed-sized arrays
         for dpv_key in self.data_per_vertex.keys():
@@ -900,8 +903,8 @@ class TrxFile:
 
     @staticmethod
     def _initialize_empty_trx(
-        nb_streamlines: int, nb_vertices: int, init_as: Optional[Type["TrxFile"]] = None
-    ) -> Type["TrxFile"]:
+            nb_streamlines: int, nb_vertices: int,
+            init_as: Optional[Type["TrxFile"]] = None) -> Type["TrxFile"]:
         """Create on-disk memmaps of a certain size (preallocation)
 
         Keyword arguments:
@@ -946,14 +949,16 @@ class TrxFile:
             tmp_dir.name, "positions.3.{}".format(positions_dtype.name)
         )
         trx.streamlines._data = _create_memmap(
-            positions_filename, mode="w+", shape=(nb_vertices, 3), dtype=positions_dtype
+            positions_filename, mode="w+", shape=(nb_vertices, 3),
+            dtype=positions_dtype
         )
 
         offsets_filename = os.path.join(
             tmp_dir.name, "offsets.{}".format(offsets_dtype.name)
         )
         trx.streamlines._offsets = _create_memmap(
-            offsets_filename, mode="w+", shape=(nb_streamlines,), dtype=offsets_dtype
+            offsets_filename, mode="w+", shape=(nb_streamlines,),
+            dtype=offsets_dtype
         )
         trx.streamlines._lengths = np.zeros(
             shape=(nb_streamlines,), dtype=lengths_dtype
@@ -1095,7 +1100,8 @@ class TrxFile:
                     shape = (trx.header["NB_STREAMLINES"], int(nb_scalar))
 
                 trx.data_per_streamline[base] = _create_memmap(
-                    filename, mode="r+", offset=mem_adress, shape=shape, dtype=ext[1:]
+                    filename, mode="r+", offset=mem_adress, shape=shape,
+                    dtype=ext[1:]
                 )
             elif folder == "dpv":
                 nb_scalar = size / trx.header["NB_VERTICES"]
@@ -1105,7 +1111,8 @@ class TrxFile:
                     shape = (trx.header["NB_VERTICES"], int(nb_scalar))
 
                 trx.data_per_vertex[base] = _create_memmap(
-                    filename, mode="r+", offset=mem_adress, shape=shape, dtype=ext[1:]
+                    filename, mode="r+", offset=mem_adress, shape=shape,
+                    dtype=ext[1:]
                 )
             elif folder.startswith("dpg"):
                 if int(size) != dim:
@@ -1119,7 +1126,8 @@ class TrxFile:
                 if sub_folder not in trx.data_per_group:
                     trx.data_per_group[sub_folder] = {}
                 trx.data_per_group[sub_folder][data_name] = _create_memmap(
-                    filename, mode="r+", offset=mem_adress, shape=shape, dtype=ext[1:]
+                    filename, mode="r+", offset=mem_adress, shape=shape,
+                    dtype=ext[1:]
                 )
             elif folder == "groups":
                 # Groups are simply indices, nothing else
@@ -1129,7 +1137,8 @@ class TrxFile:
                 else:
                     shape = (int(size),)
                 trx.groups[base] = _create_memmap(
-                    filename, mode="r+", offset=mem_adress, shape=shape, dtype=ext[1:]
+                    filename, mode="r+", offset=mem_adress, shape=shape,
+                    dtype=ext[1:]
                 )
             else:
                 logging.error(
@@ -1266,25 +1275,43 @@ class TrxFile:
                     dpg_filename, mode="w+", shape=shape, dtype=dpg_dtype
                 )
 
-                trx.data_per_group[group_key][dpg_key][:] = self.data_per_group[
-                    group_key
-                ][dpg_key]
+                trx.data_per_group[group_key][dpg_key][:] = \
+                    self.data_per_group[group_key][dpg_key]
 
         self.close()
         self.__dict__ = trx.__dict__
 
+    def get_dtype_dict(self) -> dict[str, np.dtype]:
+        """Get the dtype dictionary for the TrxFile
+
+        Returns
+            A dictionary containing the dtype for each data element
+        """
+        dtype_dict = {"positions": self.streamlines._data.dtype,
+                      "offsets": self.streamlines._offsets.dtype,
+                      "dpv": {}, "dps": {}, "dpg": {}}
+
+        for key in self.data_per_vertex.keys():
+            dtype_dict['dpv'][key] = self.data_per_vertex[key]._data.dtype
+        for key in self.data_per_streamline.keys():
+            dtype_dict['dps'][key] = self.data_per_streamline[key].dtype
+
+        return dtype_dict
+
     def append(self, obj: Union["StatefulTractogram", "TrxFile",
-                                "Tractogram", "LazyTractogram"],
+                                "Tractogram"],
                extra_buffer: int = 0) -> None:
+
+        curr_dtype_dict = self.get_dtype_dict()
 
         if not isinstance(obj, (StatefulTractogram, TrxFile,
                                 Tractogram)):
             raise TypeError("{} is not a supported object type for appending.")
         elif isinstance(obj, Tractogram):
             obj = self.from_tractogram(obj, reference=self.header,
-                                       cast_position=np.float32)
+                                       dtype_dict=curr_dtype_dict)
         elif isinstance(obj, StatefulTractogram):
-            obj = self.from_sft(obj, cast_position=np.float32)
+            obj = self.from_sft(obj, dtype_dict=curr_dtype_dict)
 
         self._append_trx(obj, extra_buffer=extra_buffer)
 
@@ -1416,7 +1443,11 @@ class TrxFile:
     @staticmethod
     def from_lazy_tractogram(obj: ["LazyTractogram"], reference,
                              extra_buffer: int = 0,
-                             chunk_size: int = 10000) -> None:
+                             chunk_size: int = 10000,
+                             dtype_dict: dict = {'positions': np.float32,
+                                                 'offsets': np.uint32,
+                                                 'dpv': {}, 'dps': {}}) \
+            -> Type["TrxFile"]:
         """Append a TrxFile to another (support buffer)
 
         Keyword arguments:
@@ -1427,7 +1458,7 @@ class TrxFile:
             chunk_size -- The number of streamlines to save at a time.
         """
 
-        data = {'strs': [], 'dpp': {}, 'dps': {}}
+        data = {'strs': [], 'dpv': {}, 'dps': {}}
         concat = None
         count = 0
         iterator = iter(obj)
@@ -1443,36 +1474,54 @@ class TrxFile:
                             concat = TrxFile()
                         else:
                             concat = TrxFile.from_tractogram(obj,
-                                                             reference=reference)
+                                                             reference=reference,
+                                                             dtype_dict=dtype_dict)
                     elif len(obj.streamlines) > 0:
                         curr_obj = TrxFile.from_tractogram(obj,
-                                                           reference=reference)
+                                                           reference=reference,
+                                                           dtype_dict=dtype_dict)
                         concat.append(curr_obj)
                     break
                 append_generator_to_dict(i, data)
             else:
                 obj = convert_data_dict_to_tractogram(data)
                 if concat is None:
-                    concat = TrxFile.from_tractogram(obj, reference=reference)
+                    concat = TrxFile.from_tractogram(obj,
+                                                     reference=reference,
+                                                     dtype_dict=dtype_dict)
                 else:
                     curr_obj = TrxFile.from_tractogram(obj,
-                                                       reference=reference)
+                                                       reference=reference,
+                                                       dtype_dict=dtype_dict)
                     concat.append(curr_obj, extra_buffer=extra_buffer)
-                data = {'strs': [], 'dpp': {}, 'dps': {}}
+                data = {'strs': [], 'dpv': {}, 'dps': {}}
                 count = 0
 
         concat.resize()
         return concat
 
     @staticmethod
-    def from_sft(sft, cast_position=np.float32):
+    def from_sft(sft, dtype_dict={}):
         """Generate a valid TrxFile from a StatefulTractogram"""
 
-        if not np.issubdtype(cast_position, np.floating):
+        if len(sft.dtype_dict) > 0:
+            dtype_dict = sft.dtype_dict
+        elif len(dtype_dict) == 0:
+            dtype_dict = {'positions': np.float32, 'offsets': np.uint32,
+                          'dpv': {}, 'dps': {}}
+
+        positions_dtype = dtype_dict['positions']
+        offsets_dtype = dtype_dict['offsets']
+
+        if not np.issubdtype(positions_dtype, np.floating):
             logging.warning(
-                "Casting as {}, considering using a floating point "
-                "dtype.".format(cast_position)
-            )
+                "Casting positions as {}, considering using a floating point "
+                "dtype.".format(positions_dtype))
+
+        if not np.issubdtype(offsets_dtype, np.integer):
+            logging.warning(
+                "Casting offsets as {}, considering using a integer "
+                "dtype.".format(offsets_dtype))
 
         trx = TrxFile(nb_vertices=len(sft.streamlines._data),
                       nb_streamlines=len(sft.streamlines))
@@ -1489,21 +1538,28 @@ class TrxFile:
         # TrxFile are written on disk in RASMM/center convention
         sft.to_rasmm()
         sft.to_center()
-        if cast_position != np.float32:
-            tmp_streamlines = deepcopy(sft.streamlines)
-        else:
-            tmp_streamlines = sft.streamlines
-        sft.to_space(old_space)
-        sft.to_origin(old_origin)
+
+        tmp_streamlines = deepcopy(sft.streamlines)
 
         # Cast the int64 of Nibabel to uint32
-        tmp_streamlines._offsets = tmp_streamlines._offsets.astype(np.uint32)
-        if cast_position != np.float32:
-            tmp_streamlines._data = tmp_streamlines._data.astype(cast_position)
+        tmp_streamlines._offsets = tmp_streamlines._offsets.astype(
+            offsets_dtype)
+        tmp_streamlines._data = tmp_streamlines._data.astype(positions_dtype)
 
         trx.streamlines = tmp_streamlines
-        trx.data_per_streamline = sft.data_per_streamline
-        trx.data_per_vertex = sft.data_per_point
+        for key in sft.data_per_point:
+            dtype_to_use = dtype_dict['dpv'][key] if key in dtype_dict['dpv'] \
+                else np.float32
+            trx.data_per_vertex[key] = \
+                sft.data_per_point[key]
+            trx.data_per_vertex[key]._data = \
+                sft.data_per_point[key]._data.astype(dtype_to_use)
+
+        for key in sft.data_per_streamline:
+            dtype_to_use = dtype_dict['dps'][key] if key in dtype_dict['dps'] \
+                else np.float32
+            trx.data_per_streamline[key] = sft.data_per_streamline[key].astype(
+                dtype_to_use)
 
         # For safety and for RAM, convert the whole object to memmaps
         tmpdir = get_trx_tmpdir()
@@ -1511,16 +1567,33 @@ class TrxFile:
         trx = load_from_directory(tmpdir.name)
         trx._uncompressed_folder_handle = tmpdir
 
+        sft.to_space(old_space)
+        sft.to_origin(old_origin)
+        del tmp_streamlines
+
         return trx
 
     @staticmethod
-    def from_tractogram(tractogram, reference, cast_position=np.float32):
+    def from_tractogram(tractogram, reference,
+                        dtype_dict={'positions': np.float32,
+                                    'offsets': np.uint32,
+                                    'dpv': {}, 'dps': {}}):
         """Generate a valid TrxFile from a Nibabel Tractogram"""
-        if not np.issubdtype(cast_position, np.floating):
+
+        positions_dtype = dtype_dict['positions'] if 'positions' in dtype_dict \
+            else np.float32
+        offsets_dtype = dtype_dict['offsets'] if 'offsets' in dtype_dict \
+            else np.uint32
+
+        if not np.issubdtype(positions_dtype, np.floating):
             logging.warning(
-                "Casting as {}, considering using a floating point "
-                "dtype.".format(cast_position)
-            )
+                "Casting positions as {}, considering using a floating point "
+                "dtype.".format(positions_dtype))
+
+        if not np.issubdtype(offsets_dtype, np.integer):
+            logging.warning(
+                "Casting offsets as {}, considering using a integer "
+                "dtype.".format(offsets_dtype))
 
         trx = TrxFile(
             nb_vertices=len(tractogram.streamlines._data),
@@ -1535,25 +1608,34 @@ class TrxFile:
             "NB_STREAMLINES": len(tractogram.streamlines),
         }
 
-        if cast_position != np.float32:
-            tmp_streamlines = deepcopy(tractogram.streamlines)
-        else:
-            tmp_streamlines = tractogram.streamlines
+        tmp_streamlines = deepcopy(tractogram.streamlines)
 
         # Cast the int64 of Nibabel to uint32
-        tmp_streamlines._offsets = tmp_streamlines._offsets.astype(np.uint32)
-        if cast_position != np.float32:
-            tmp_streamlines._data = tmp_streamlines._data.astype(cast_position)
+        tmp_streamlines._offsets = tmp_streamlines._offsets.astype(
+            offsets_dtype)
+        tmp_streamlines._data = tmp_streamlines._data.astype(positions_dtype)
 
         trx.streamlines = tmp_streamlines
-        trx.data_per_streamline = tractogram.data_per_streamline
-        trx.data_per_vertex = tractogram.data_per_point
+        for key in tractogram.data_per_point:
+            dtype_to_use = dtype_dict['dpv'][key] if key in dtype_dict['dpv'] \
+                else np.float32
+            trx.data_per_vertex[key] = \
+                tractogram.data_per_point[key]
+            trx.data_per_vertex[key]._data = \
+                tractogram.data_per_point[key]._data.astype(dtype_to_use)
+
+        for key in tractogram.data_per_streamline:
+            dtype_to_use = dtype_dict['dps'][key] if key in dtype_dict['dps'] \
+                else np.float32
+            trx.data_per_streamline[key] = \
+                tractogram.data_per_streamline[key].astype(dtype_to_use)
 
         # For safety and for RAM, convert the whole object to memmaps
         tmpdir = get_trx_tmpdir()
         save(trx, tmpdir.name)
         trx = load_from_directory(tmpdir.name)
         trx._uncompressed_folder_handle = tmpdir
+        del tmp_streamlines
 
         return trx
 
@@ -1625,6 +1707,7 @@ class TrxFile:
             data_per_point=self.data_per_vertex,
             data_per_streamline=self.data_per_streamline,
         )
+        sft.dtype_dict = self.get_dtype_dict()
 
         return sft
 

--- a/trx/trx_file_memmap.py
+++ b/trx/trx_file_memmap.py
@@ -424,8 +424,6 @@ def concatenate(
                 ref_trx.data_per_vertex[key]._data.dtype
                 != curr_trx.data_per_vertex[key]._data.dtype
             ):
-                print(key, ref_trx.data_per_vertex[key]._data.dtype,
-                      curr_trx.data_per_vertex[key]._data.dtype)
                 logging.debug(
                     "{} dpv key is not declared with the same dtype "
                     "in all TrxFile.".format(key)
@@ -1515,6 +1513,8 @@ class TrxFile:
 
         if len(sft.dtype_dict) > 0:
             dtype_dict = sft.dtype_dict
+        if 'dpp' in dtype_dict:
+            dtype_dict['dpv'] = dtype_dict.pop('dpp')
         elif len(dtype_dict) == 0:
             dtype_dict = {'positions': np.float32, 'offsets': np.uint32,
                           'dpv': {}, 'dps': {}}
@@ -1716,6 +1716,9 @@ class TrxFile:
             data_per_point=self.data_per_vertex,
             data_per_streamline=self.data_per_streamline,
         )
+        tmp_dict = self.get_dtype_dict()
+        if 'dpv' in tmp_dict:
+            tmp_dict['dpp'] = tmp_dict.pop('dpv')
         sft.dtype_dict = self.get_dtype_dict()
 
         return sft

--- a/trx/utils.py
+++ b/trx/utils.py
@@ -393,18 +393,20 @@ def convert_data_dict_to_tractogram(data):
     streamlines._data = streamlines._data
 
     for key in data['dps']:
-        data['dps'][key] = np.array(data['dps'][key])
+        shape = (len(streamlines), len(data['dps'][key]) // len(streamlines))
+        data['dps'][key] = np.array(data['dps'][key]).reshape(shape)
 
-    data['data_per_point'] = {}
-    for key in data['dpp']:
-        if key not in data['data_per_point']:
-            tmp_arr = ArraySequence()
-            tmp_arr._data = data['dpp'][key]
-            tmp_arr._offsets = streamlines._offsets
-            tmp_arr._lengths = streamlines._lengths
-            data['data_per_point'][key] = tmp_arr
+    for key in data['dpv']:
+        shape = (len(streamlines._data), len(data['dpv'][key]) // len(streamlines._data))
+        data['dpv'][key] = np.array(data['dpv'][key]).reshape(shape)
 
-    obj = Tractogram(streamlines, data_per_point=data['data_per_point'],
+        tmp_arr = ArraySequence()
+        tmp_arr._data = data['dpv'][key]
+        tmp_arr._offsets = streamlines._offsets
+        tmp_arr._lengths = streamlines._lengths
+        data['dpv'][key] = tmp_arr
+
+    obj = Tractogram(streamlines, data_per_point=data['dpv'],
                      data_per_streamline=data['dps'])
 
     return obj
@@ -414,10 +416,10 @@ def append_generator_to_dict(gen, data):
     if isinstance(gen, TractogramItem):
         data['strs'].append(gen.streamline.tolist())
         for key in gen.data_for_points:
-            if key not in data['dpp']:
-                data['dpp'][key] = np.array([])
-            data['dpp'][key] = np.append(
-                data['dpp'][key], gen.data_for_points[key])
+            if key not in data['dpv']:
+                data['dpv'][key] = np.array([])
+            data['dpv'][key] = np.append(
+                data['dpv'][key], gen.data_for_points[key])
         for key in gen.data_for_streamline:
             if key not in data['dps']:
                 data['dps'][key] = np.array([])

--- a/trx/workflows.py
+++ b/trx/workflows.py
@@ -228,9 +228,11 @@ def validate_tractogram(in_tractogram, reference, out_tractogram,
         sft = tractogram_obj.to_sft()
     else:
         sft = tractogram_obj
-    # print(sft)
+
+    ori_dtype = sft.dtype_dict
     ori_len = len(sft)
     tot_remove = 0
+
     invalid_coord_ind, _ = sft.remove_invalid_streamlines()
     tot_remove += len(invalid_coord_ind)
     logging.warning('Removed {} streamlines with invalid coordinates.'.format(
@@ -269,15 +271,16 @@ def validate_tractogram(in_tractogram, reference, out_tractogram,
     if out_tractogram:
         streamlines = sft.streamlines[indices_final].copy()
         dpp = {}
-        for key in dpp.keys():
-            dpp[key] = sft.data_per_point[key][indices_final]
+        for key in sft.data_per_point.keys():
+            dpp[key] = sft.data_per_point[key][indices_final].copy()
 
         dps = {}
-        for key in dps.keys():
+        for key in sft.data_per_streamline.keys():
             dps[key] = sft.data_per_streamline[key][indices_final]
         new_sft = StatefulTractogram.from_sft(streamlines, sft,
                                               data_per_point=dpp,
                                               data_per_streamline=dps)
+        new_sft.dtype_dict = ori_dtype
         save(new_sft, out_tractogram)
 
 

--- a/trx/workflows.py
+++ b/trx/workflows.py
@@ -224,11 +224,13 @@ def tractogram_visualize_overlap(in_tractogram, reference, remove_invalid=True):
 def validate_tractogram(in_tractogram, reference, out_tractogram,
                         remove_identical_streamlines=True, precision=1):
     tractogram_obj = load(in_tractogram, reference)
+    
     if not isinstance(tractogram_obj, StatefulTractogram):
         sft = tractogram_obj.to_sft()
     else:
         sft = tractogram_obj
 
+    
     ori_dtype = sft.dtype_dict
     ori_len = len(sft)
     tot_remove = 0


### PR DESCRIPTION
In order to actually be useful in real-life, I had to include a system to indicate how to change datatype.

An example of this in scilpy is tracking when using LazyTractogram, we are also saving the initial seed position (N, 3) in the data_per_streamline.

The problem was that Nibabel was storing everything in float64, at save time everything is saved as float32 (in TRK/TCK)
But then the TRX was just saving it as it was stored (float64) so I had to include a way "for the user" to say what should be saved how.

This was already ok when creating a TRX from scratch, but when converting from StatefulTractogram in Dipy, or Tractogram in Nibabel to TrxFile it was not trivial to do `.astype()` on everything easily.

This comes with a big PR in Scilpy since we have like 150 scripts, but also it comes with a tiny change in Dipy so StatefulTractogram could hide a record of the dtype by itself.

This is evolving:
- [x] Make a command line script that will take a TRX as input and a TRX as output and a bunch of tag to change the dtype of any specific file inside the TRX (easier than extracting it, loading and saving every array manually and re-generating from scratch again)
- [ ] Double check all scripts involving streamlines in Scilpy to make sure they keep the right dtype (if possible)
- [ ] Check the performance of using TRX on a script using QBx or Recobundles on a whole brain
- [ ] Doing a PR in Dipy (so one day we can do a clean Dipy install of the next tag)
- [ ] Doing a PR in Scilpy for basic support of TRX (no crazy memmapping, just load/save without loosing info)
- [ ] Add test for load/save with a mix of `to_*` and `from_*` function (sft, memory, tractogram, etc.)

https://github.com/frheault/dipy/tree/trx_integration
https://github.com/frheault/scilpy/tree/trx_integration