### PR TITLE
Always use latest ubuntu in GA.

### DIFF
--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -4,7 +4,7 @@ on: push
 jobs:
   build-n-publish:
     name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
     - name: Set up Python 3.9


### PR DESCRIPTION
This is the reason that the most recent micro release did not make it to pypi.

See: https://stackoverflow.com/a/70968478