### PR TITLE
Manual cleanup to go around Windows errors

### DIFF
--- a/trx/io.py
+++ b/trx/io.py
@@ -22,9 +22,24 @@ def get_trx_tmpdir():
             trx_tmp_dir = os.getenv('TRX_TMPDIR')
     else:
         trx_tmp_dir = tempfile.gettempdir()
-
     return tempfile.TemporaryDirectory(dir=trx_tmp_dir, prefix='trx_')
-
+    # Step 1: Traverse the directory tree
+    for dirpath, dirnames, filenames in os.walk(tmpdir_path, topdown=False):
+        
+        # Step 2 and 3: Identify and remove symlinks (for files)
+        for filename in filenames:
+            filepath = os.path.join(dirpath, filename)
+            if os.path.islink(filepath):
+                os.unlink(filepath)
+        
+        # Step 2 and 3: Identify and remove symlinks (for directories)
+        for dirname in dirnames:
+            dir_full_path = os.path.join(dirpath, dirname)
+            if os.path.islink(dir_full_path):
+                os.unlink(dir_full_path)
+    
+    # Step 4: Remove the temporary directory
+    shutil.rmtree(tmpdir_path)
 
 def load_sft_with_reference(filepath, reference=None,
                             bbox_check=True):
@@ -72,7 +87,7 @@ def load(tractogram_filename, reference):
 def save(tractogram_obj, tractogram_filename, bbox_valid_check=False):
     if not dipy_available:
         logging.error('Dipy library is missing, cannot use functions related '
-                    'to the StatefulTractogram.')
+                      'to the StatefulTractogram.')
         return None
     from dipy.io.stateful_tractogram import StatefulTractogram
     from dipy.io.streamline import save_tractogram

--- a/trx/io.py
+++ b/trx/io.py
@@ -22,24 +22,9 @@ def get_trx_tmpdir():
             trx_tmp_dir = os.getenv('TRX_TMPDIR')
     else:
         trx_tmp_dir = tempfile.gettempdir()
+
     return tempfile.TemporaryDirectory(dir=trx_tmp_dir, prefix='trx_')
-    # Step 1: Traverse the directory tree
-    for dirpath, dirnames, filenames in os.walk(tmpdir_path, topdown=False):
-        
-        # Step 2 and 3: Identify and remove symlinks (for files)
-        for filename in filenames:
-            filepath = os.path.join(dirpath, filename)
-            if os.path.islink(filepath):
-                os.unlink(filepath)
-        
-        # Step 2 and 3: Identify and remove symlinks (for directories)
-        for dirname in dirnames:
-            dir_full_path = os.path.join(dirpath, dirname)
-            if os.path.islink(dir_full_path):
-                os.unlink(dir_full_path)
-    
-    # Step 4: Remove the temporary directory
-    shutil.rmtree(tmpdir_path)
+
 
 def load_sft_with_reference(filepath, reference=None,
                             bbox_check=True):
@@ -87,7 +72,7 @@ def load(tractogram_filename, reference):
 def save(tractogram_obj, tractogram_filename, bbox_valid_check=False):
     if not dipy_available:
         logging.error('Dipy library is missing, cannot use functions related '
-                      'to the StatefulTractogram.')
+                    'to the StatefulTractogram.')
         return None
     from dipy.io.stateful_tractogram import StatefulTractogram
     from dipy.io.streamline import save_tractogram

--- a/trx/trx_file_memmap.py
+++ b/trx/trx_file_memmap.py
@@ -1736,6 +1736,24 @@ class TrxFile:
     def close(self) -> None:
         """Cleanup on-disk temporary folder and initialize an empty TrxFile"""
         if self._uncompressed_folder_handle is not None:
-            self._uncompressed_folder_handle.cleanup()
+            # Problem on Windows that is solving only in Python above 3.10
+            # Step 1: Traverse the directory tree
+            for dirpath, dirnames, filenames in \
+                os.walk(self._uncompressed_folder_handle.name, topdown=False):
+                
+                # Step 2 and 3: Identify and remove symlinks (for files)
+                for filename in filenames:
+                    filepath = os.path.join(dirpath, filename)
+                    if os.path.islink(filepath):
+                        os.unlink(filepath)
+                
+                # Step 2 and 3: Identify and remove symlinks (for directories)
+                for dirname in dirnames:
+                    dir_full_path = os.path.join(dirpath, dirname)
+                    if os.path.islink(dir_full_path):
+                        os.unlink(dir_full_path)
+            
+            # Step 4: Remove the temporary directory
+            shutil.rmtree(self._uncompressed_folder_handle.name)
         self.__init__()
         logging.debug("Deleted memmaps and intialized empty TrxFile.")


### PR DESCRIPTION
Attempt to manually cleanup the tmp_dir since a parameter in tempfile library does not exist in Python3.9

https://www.scivision.dev/python-tempfile-permission-error-windows/