### PR TITLE
Try_except with warning

### DIFF
--- a/scripts/tests/test_workflows.py
+++ b/scripts/tests/test_workflows.py
@@ -30,17 +30,17 @@ tmp_dir = get_trx_tmpdir()
 
 
 def test_help_option_convert_dsi(script_runner):
-    ret = script_runner.run('tff_convert_dsi_studio.py', '--help')
+    ret = script_runner.run(['tff_convert_dsi_studio.py', '--help'])
     assert ret.success
 
 
 def test_help_option_convert(script_runner):
-    ret = script_runner.run('tff_convert_tractogram.py', '--help')
+    ret = script_runner.run(['tff_convert_tractogram.py', '--help'])
     assert ret.success
 
 
 def test_help_option_generate_trx_from_scratch(script_runner):
-    ret = script_runner.run('tff_generate_trx_from_scratch.py', '--help')
+    ret = script_runner.run(['tff_generate_trx_from_scratch.py', '--help'])
     assert ret.success
 
 
@@ -210,6 +210,7 @@ def test_execution_generate_trx_from_scratch():
                              gen_trx.data_per_group[group][key])
     exp_trx.close()
     gen_trx.close()
+
 
 @pytest.mark.skipif(not dipy_available,
                     reason='Dipy is not installed.')

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,7 @@ doc = astroid==2.15.8
 
 test =
     flake8
+    psutil
     pytest >= 7
     pytest-console-scripts >= 0
 

--- a/trx/io.py
+++ b/trx/io.py
@@ -4,6 +4,7 @@
 import os
 import logging
 import tempfile
+import sys
 
 try:
     import dipy
@@ -23,7 +24,11 @@ def get_trx_tmpdir():
     else:
         trx_tmp_dir = tempfile.gettempdir()
 
-    return tempfile.TemporaryDirectory(dir=trx_tmp_dir, prefix='trx_')
+    if sys.version_info[1] >= 10:
+        return tempfile.TemporaryDirectory(dir=trx_tmp_dir, prefix='trx_',
+                                           ignore_cleanup_errors=True)
+    else:
+        return tempfile.TemporaryDirectory(dir=trx_tmp_dir, prefix='trx_')
 
 
 def load_sft_with_reference(filepath, reference=None,
@@ -72,7 +77,7 @@ def load(tractogram_filename, reference):
 def save(tractogram_obj, tractogram_filename, bbox_valid_check=False):
     if not dipy_available:
         logging.error('Dipy library is missing, cannot use functions related '
-                    'to the StatefulTractogram.')
+                      'to the StatefulTractogram.')
         return None
     from dipy.io.stateful_tractogram import StatefulTractogram
     from dipy.io.streamline import save_tractogram

--- a/trx/tests/test_io.py
+++ b/trx/tests/test_io.py
@@ -113,6 +113,9 @@ def test_close_tmp_file(path):
     sft.to_vox()
     assert_allclose(sft.streamlines._data, coord_vox, rtol=1e-04, atol=1e-06)
 
+    trx3 = tmm.load(path)
+    assert_allclose(trx3.streamlines._data, coord_rasmm, rtol=1e-04, atol=1e-06)
+    trx3.close()
 
 @pytest.mark.parametrize("tmp_path", [("~"), ("use_working_dir")])
 def test_change_tmp_dir(tmp_path):

--- a/trx/tests/test_io.py
+++ b/trx/tests/test_io.py
@@ -88,7 +88,7 @@ def test_close_tmp_file(path):
     path = os.path.join(dir, path)
 
     trx1 = tmm.load(path)
-    tmp_dir = deepcopy(trx._uncompressed_folder_handle.name)
+    tmp_dir = deepcopy(trx1._uncompressed_folder_handle.name)
     if os.path.isfile(path):
         assert os.path.isdir(tmp_dir)
     sft = trx1.to_sft()

--- a/trx/tests/test_io.py
+++ b/trx/tests/test_io.py
@@ -88,8 +88,8 @@ def test_close_tmp_file(path):
     path = os.path.join(dir, path)
 
     trx1 = tmm.load(path)
-    tmp_dir = deepcopy(trx1._uncompressed_folder_handle.name)
     if os.path.isfile(path):
+        tmp_dir = deepcopy(trx1._uncompressed_folder_handle.name)
         assert os.path.isdir(tmp_dir)
     sft = trx1.to_sft()
     trx1.close()
@@ -102,7 +102,9 @@ def test_close_tmp_file(path):
     # The folder trx representation does not need tmp files
     if os.path.isfile(path):
         assert not os.path.isdir(tmp_dir)
+
     assert_allclose(sft.streamlines._data, coord_rasmm, rtol=1e-04, atol=1e-06)
+    
     # Reloading the TRX and checking its data, then closing
     trx2 = tmm.load(path)
     assert_allclose(trx2.streamlines._data, sft.streamlines._data, rtol=1e-04, atol=1e-06)
@@ -113,7 +115,7 @@ def test_close_tmp_file(path):
 
 
 @pytest.mark.parametrize("tmp_path", [("~"), ("use_working_dir")])
-def test_close_tmp_file(tmp_path):
+def test_change_tmp_dir(tmp_path):
     dir = os.path.join(get_home(), 'gold_standard')
     path = os.path.join(dir, 'gs.trx')
 

--- a/trx/tests/test_io.py
+++ b/trx/tests/test_io.py
@@ -105,3 +105,25 @@ def test_close_tmp_file(path):
     assert_allclose(sft.streamlines._data, coord_rasmm, rtol=1e-04, atol=1e-06)
     sft.to_vox()
     assert_allclose(sft.streamlines._data, coord_vox, rtol=1e-04, atol=1e-06)
+
+
+@pytest.mark.parametrize("tmp_path", [("~"), ("use_working_dir")])
+def test_close_tmp_file(tmp_path):
+    dir = os.path.join(get_home(), 'gold_standard')
+    path = os.path.join(dir, 'gs.trx')
+
+    if tmp_path == 'use_working_dir':
+        os.environ['TRX_TMPDIR'] = 'use_working_dir'
+    else:
+        os.environ['TRX_TMPDIR'] = os.path.expanduser(tmp_path)
+
+    trx = tmm.load(path)
+    tmp_dir = deepcopy(trx._uncompressed_folder_handle)
+
+    if tmp_path == 'use_working_dir':
+        assert os.path.dirname(tmp_dir.name) == os.getcwd()
+    else:
+        assert os.path.dirname(tmp_dir.name) == os.path.expanduser(tmp_path)
+
+    trx.close()
+    assert not os.path.isdir(tmp_dir.name)

--- a/trx/tests/test_io.py
+++ b/trx/tests/test_io.py
@@ -89,6 +89,8 @@ def test_close_tmp_file(path):
 
     trx = tmm.load(path)
     tmp_dir = deepcopy(trx._uncompressed_folder_handle)
+    if os.path.isfile(path):
+        assert os.path.isdir(tmp_dir.name)
     sft = trx.to_sft()
     trx.close()
 

--- a/trx/tests/test_io.py
+++ b/trx/tests/test_io.py
@@ -37,6 +37,8 @@ def test_load_vox(path):
     sft.to_vox()
 
     assert_allclose(sft.streamlines._data, coord, rtol=1e-04, atol=1e-06)
+    if isinstance(obj, TrxFile):
+        obj.close()
 
 
 @pytest.mark.parametrize("path", [("gs.trx"), ("gs.trk"), ("gs.tck"),
@@ -53,6 +55,8 @@ def test_load_voxmm(path):
     sft.to_voxmm()
 
     assert_allclose(sft.streamlines._data, coord, rtol=1e-04, atol=1e-06)
+    if isinstance(obj, TrxFile):
+        obj.close()
 
 
 @pytest.mark.parametrize("path", [("gs.trk"), ("gs.trx"), ("gs_fldr.trx")])
@@ -68,6 +72,8 @@ def test_multi_load_save_rasmm(path):
     obj = load(path, os.path.join(dir, 'gs.nii'))
     for _ in range(100):
         save(obj, out_path)
+        if isinstance(obj, TrxFile):
+            obj.close()
         obj = load(out_path, os.path.join(dir, 'gs.nii'))
 
     assert_allclose(obj.streamlines._data, coord, rtol=1e-04, atol=1e-06)

--- a/trx/tests/test_io.py
+++ b/trx/tests/test_io.py
@@ -87,12 +87,12 @@ def test_close_tmp_file(path):
     dir = os.path.join(get_home(), 'gold_standard')
     path = os.path.join(dir, path)
 
-    trx = tmm.load(path)
-    tmp_dir = deepcopy(trx._uncompressed_folder_handle)
+    trx1 = tmm.load(path)
+    tmp_dir = deepcopy(trx._uncompressed_folder_handle.name)
     if os.path.isfile(path):
-        assert os.path.isdir(tmp_dir.name)
-    sft = trx.to_sft()
-    trx.close()
+        assert os.path.isdir(tmp_dir)
+    sft = trx1.to_sft()
+    trx1.close()
 
     coord_rasmm = np.loadtxt(os.path.join(get_home(), 'gold_standard',
                                           'gs_rasmm_space.txt'))
@@ -101,8 +101,13 @@ def test_close_tmp_file(path):
 
     # The folder trx representation does not need tmp files
     if os.path.isfile(path):
-        assert not os.path.isdir(tmp_dir.name)
+        assert not os.path.isdir(tmp_dir)
     assert_allclose(sft.streamlines._data, coord_rasmm, rtol=1e-04, atol=1e-06)
+    # Reloading the TRX and checking its data, then closing
+    trx2 = tmm.load(path)
+    assert_allclose(trx2.streamlines._data, sft.streamlines._data, rtol=1e-04, atol=1e-06)
+    trx2.close()
+
     sft.to_vox()
     assert_allclose(sft.streamlines._data, coord_vox, rtol=1e-04, atol=1e-06)
 
@@ -118,12 +123,12 @@ def test_close_tmp_file(tmp_path):
         os.environ['TRX_TMPDIR'] = os.path.expanduser(tmp_path)
 
     trx = tmm.load(path)
-    tmp_dir = deepcopy(trx._uncompressed_folder_handle)
+    tmp_dir = deepcopy(trx._uncompressed_folder_handle.name)
 
     if tmp_path == 'use_working_dir':
-        assert os.path.dirname(tmp_dir.name) == os.getcwd()
+        assert os.path.dirname(tmp_dir) == os.getcwd()
     else:
-        assert os.path.dirname(tmp_dir.name) == os.path.expanduser(tmp_path)
+        assert os.path.dirname(tmp_dir) == os.path.expanduser(tmp_path)
 
     trx.close()
-    assert not os.path.isdir(tmp_dir.name)
+    assert not os.path.isdir(tmp_dir)

--- a/trx/tests/test_memmap.py
+++ b/trx/tests/test_memmap.py
@@ -188,7 +188,11 @@ def test_concatenate(path):
     trx1 = tmm.load(path)
     trx2 = tmm.load(path)
     concat = tmm.concatenate([trx1, trx2])
+
     assert len(concat) == 2 * len(trx2)
+    trx1.close()
+    trx2.close()
+    concat.close()
 
 
 @pytest.mark.parametrize("path", [("small.trx")])
@@ -200,7 +204,10 @@ def test_resize(path):
 
     tmm.concatenate([concat, trx1], preallocation=True, delete_groups=True)
     concat.resize()
+
     assert len(concat) == len(trx1)
+    trx1.close()
+    concat.close()
 
 
 @pytest.mark.parametrize(
@@ -219,7 +226,10 @@ def test_append(path, buffer):
     concat.append(trx1, extra_buffer=buffer)
     if buffer > 0:
         concat.resize()
+
     assert len(concat) == len(trx1)
+    trx1.close()
+    concat.close()
 
 
 @pytest.mark.parametrize("path, buffer", [("small.trx", 10000)])
@@ -233,7 +243,10 @@ def test_append_StatefulTractogram(path, buffer):
     concat.append(obj, extra_buffer=buffer)
     if buffer > 0:
         concat.resize()
+
     assert len(concat) == len(obj)
+    trx.close()
+    concat.close()
 
 
 @pytest.mark.parametrize("path, buffer", [("small.trx", 10000)])
@@ -246,7 +259,10 @@ def test_append_Tractogram(path, buffer):
     concat.append(obj, extra_buffer=buffer)
     if buffer > 0:
         concat.resize()
+
     assert len(concat) == len(obj)
+    trx.close()
+    concat.close()
 
 
 @pytest.mark.parametrize("path, size, buffer", [("small.trx", 50, 10000),

--- a/trx/trx_file_memmap.py
+++ b/trx/trx_file_memmap.py
@@ -233,7 +233,7 @@ def load(input_obj: str, check_dpg: bool = True) -> Type["TrxFile"]:
                 trx = load_from_directory(tmpdir.name)
                 trx._uncompressed_folder_handle = tmpdir
                 logging.info(
-                    "File was compressed, call the close() " "function before"
+                    "File was compressed, call the close() function before"
                     "exiting."
                 )
         else:

--- a/trx/trx_file_memmap.py
+++ b/trx/trx_file_memmap.py
@@ -1736,24 +1736,10 @@ class TrxFile:
     def close(self) -> None:
         """Cleanup on-disk temporary folder and initialize an empty TrxFile"""
         if self._uncompressed_folder_handle is not None:
-            # Problem on Windows that is solving only in Python above 3.10
-            # Step 1: Traverse the directory tree
-            for dirpath, dirnames, filenames in \
-                os.walk(self._uncompressed_folder_handle.name, topdown=False):
-                
-                # Step 2 and 3: Identify and remove symlinks (for files)
-                for filename in filenames:
-                    filepath = os.path.join(dirpath, filename)
-                    if os.path.islink(filepath):
-                        os.unlink(filepath)
-                
-                # Step 2 and 3: Identify and remove symlinks (for directories)
-                for dirname in dirnames:
-                    dir_full_path = os.path.join(dirpath, dirname)
-                    if os.path.islink(dir_full_path):
-                        os.unlink(dir_full_path)
-            
-            # Step 4: Remove the temporary directory
-            shutil.rmtree(self._uncompressed_folder_handle.name)
+            try:
+                self._uncompressed_folder_handle.cleanup()
+            except PermissionError:
+                logging.error("Windows PermissionError, temporary directory {}" +
+                              "was not deleted!".format(self._uncompressed_folder_handle.name))
         self.__init__()
         logging.debug("Deleted memmaps and intialized empty TrxFile.")


### PR DESCRIPTION
@arokem I don't understand why tempfile.gettempdir() is returning a path for which we can't delete (PermissionError) in the Dipy test (but our pass).

What do you think? @skoudoro ? What I added in this PR is probably a good practice (trying to delete the folder, catch an error, and give a better error message). 

On top of this for Dipy in my tests, I could set the environment variable (os.getenv('TRX_TMPDIR')) to some path I do have permissions (any suggestion of a path directory that I could use?)