### PR TITLE
New test to match Dipy potential issue with sft copy

### DIFF
--- a/scripts/tests/test_workflows.py
+++ b/scripts/tests/test_workflows.py
@@ -15,7 +15,7 @@ except ImportError:
 
 from trx.fetcher import (get_testing_files_dict,
                          fetch_data, get_home)
-from trx.io import get_trx_tmpdir
+from trx.io import get_trx_tmp_dir
 import trx.trx_file_memmap as tmm
 from trx.workflows import (convert_dsi_studio,
                            convert_tractogram,
@@ -26,7 +26,7 @@ from trx.workflows import (convert_dsi_studio,
 
 # If they already exist, this only takes 5 seconds (check md5sum)
 fetch_data(get_testing_files_dict(), keys=['DSI.zip', 'trx_from_scratch.zip'])
-tmp_dir = get_trx_tmpdir()
+tmp_dir = get_trx_tmp_dir()
 
 
 def test_help_option_convert_dsi(script_runner):

--- a/trx/io.py
+++ b/trx/io.py
@@ -15,7 +15,7 @@ except ImportError:
 from trx.utils import split_name_with_gz
 
 
-def get_trx_tmpdir():
+def get_trx_tmp_dir():
     if os.getenv('TRX_TMPDIR') is not None:
         if os.getenv('TRX_TMPDIR') == 'use_working_dir':
             trx_tmp_dir = os.getcwd()

--- a/trx/streamlines_ops.py
+++ b/trx/streamlines_ops.py
@@ -29,7 +29,7 @@ def union(left, right):
 
 def get_streamline_key(streamline, precision=None):
     """Produces a key using a hash from a streamline using a few points only and
-    the desired precision 
+    the desired precision
 
     Parameters
     ----------

--- a/trx/tests/test_memmap.py
+++ b/trx/tests/test_memmap.py
@@ -14,14 +14,14 @@ try:
 except ImportError:
     dipy_available = False
 
-from trx.io import get_trx_tmpdir
+from trx.io import get_trx_tmp_dir
 import trx.trx_file_memmap as tmm
 from trx.fetcher import (get_testing_files_dict,
                          fetch_data, get_home)
 
 
 fetch_data(get_testing_files_dict(), keys=['memmap_test_data.zip'])
-tmp_dir = get_trx_tmpdir()
+tmp_dir = get_trx_tmp_dir()
 
 
 @pytest.mark.parametrize(
@@ -129,7 +129,7 @@ def test__dichotomic_search(arr, l_bound, r_bound, expected):
 def test__create_memmap(basename, create, expected):
     if create:
         # Need to create array before evaluating
-        with get_trx_tmpdir() as dirname:
+        with get_trx_tmp_dir() as dirname:
             filename = os.path.join(dirname, basename)
             fp = np.memmap(filename, dtype=np.int16, mode="w+", shape=(3, 4))
             fp[:] = expected[:]
@@ -138,7 +138,7 @@ def test__create_memmap(basename, create, expected):
             assert np.array_equal(mmarr, expected)
 
     else:
-        with get_trx_tmpdir() as dirname:
+        with get_trx_tmp_dir() as dirname:
             filename = os.path.join(dirname, basename)
             mmarr = tmm._create_memmap(filename=filename, shape=(0,),
                                        dtype=np.int16)

--- a/trx/trx_file_memmap.py
+++ b/trx/trx_file_memmap.py
@@ -27,7 +27,7 @@ from trx.utils import (append_generator_to_dict,
 try:
     import dipy
     dipy_available = True
-except:
+except ImportError:
     dipy_available = False
 
 
@@ -1752,7 +1752,7 @@ class TrxFile:
             try:
                 self._uncompressed_folder_handle.cleanup()
             except PermissionError:
-                logging.error("Windows PermissionError, temporary directory {}" +
+                logging.error("Windows PermissionError, temporary directory {}"
                               "was not deleted!".format(self._uncompressed_folder_handle.name))
         self.__init__()
         logging.debug("Deleted memmaps and intialized empty TrxFile.")

--- a/trx/trx_file_memmap.py
+++ b/trx/trx_file_memmap.py
@@ -18,7 +18,7 @@ from nibabel.streamlines.trk import TrkFile
 from nibabel.streamlines.tractogram import Tractogram, LazyTractogram
 import numpy as np
 
-from trx.io import get_trx_tmpdir
+from trx.io import get_trx_tmp_dir
 from trx.utils import (append_generator_to_dict,
                        close_or_delete_mmap,
                        convert_data_dict_to_tractogram,
@@ -229,7 +229,7 @@ def load(input_obj: str, check_dpg: bool = True) -> Type["TrxFile"]:
                     break
         if was_compressed:
             with zipfile.ZipFile(input_obj, "r") as zf:
-                tmpdir = get_trx_tmpdir()
+                tmpdir = get_trx_tmp_dir()
                 zf.extractall(tmpdir.name)
                 trx = load_from_directory(tmpdir.name)
                 trx._uncompressed_folder_handle = tmpdir
@@ -740,7 +740,7 @@ class TrxFile:
         Returns
             A deepcopied TrxFile of the current TrxFile
         """
-        tmp_dir = get_trx_tmpdir()
+        tmp_dir = get_trx_tmp_dir()
         out_json = open(os.path.join(tmp_dir.name, "header.json"), "w")
         tmp_header = deepcopy(self.header)
 
@@ -917,7 +917,7 @@ class TrxFile:
             An empty TrxFile preallocated with a certain size
         """
         trx = TrxFile()
-        tmp_dir = get_trx_tmpdir()
+        tmp_dir = get_trx_tmp_dir()
         logging.info("Temporary folder for memmaps: {}".format(tmp_dir.name))
 
         trx.header["NB_VERTICES"] = nb_vertices
@@ -1582,7 +1582,7 @@ class TrxFile:
                 dtype_to_use)
 
         # For safety and for RAM, convert the whole object to memmaps
-        tmpdir = get_trx_tmpdir()
+        tmpdir = get_trx_tmp_dir()
         save(trx, tmpdir.name)
         trx = load_from_directory(tmpdir.name)
         trx._uncompressed_folder_handle = tmpdir
@@ -1651,7 +1651,7 @@ class TrxFile:
                 tractogram.data_per_streamline[key].astype(dtype_to_use)
 
         # For safety and for RAM, convert the whole object to memmaps
-        tmpdir = get_trx_tmpdir()
+        tmpdir = get_trx_tmp_dir()
         save(trx, tmpdir.name)
         trx = load_from_directory(tmpdir.name)
         trx._uncompressed_folder_handle = tmpdir

--- a/trx/utils.py
+++ b/trx/utils.py
@@ -417,7 +417,7 @@ def verify_trx_dtype(trx, dict_dtype):
     trx : Tractogram
         Tractogram to verify.
     dict_dtype : dict
-        Dictionary containing the dtype to verify.
+        Dictionary containing all elements dtype to verify.
     Returns
     -------
     output : bool

--- a/trx/utils.py
+++ b/trx/utils.py
@@ -36,7 +36,7 @@ def close_or_delete_mmap(obj):
     elif isinstance(obj, np.memmap):
         del obj
     else:
-        logging.warning('Object to be close or deleted must be np.memmap')
+        logging.debug('Object to be close or deleted must be np.memmap')
 
 
 def split_name_with_gz(filename):

--- a/trx/workflows.py
+++ b/trx/workflows.py
@@ -311,7 +311,7 @@ def generate_trx_from_scratch(reference, out_tractogram, positions_csv=False,
                               space_str='rasmm', origin_str='nifti',
                               verify_invalid=True, dpv=[], dps=[],
                               groups=[], dpg=[]):
-    with get_trx_tmp_dir() as tmpdirname:
+    with get_trx_tmp_dir() as tmp_dir_name:
         if positions_csv:
             with open(positions_csv, newline='') as f:
                 reader = csv.reader(f)
@@ -360,20 +360,20 @@ def generate_trx_from_scratch(reference, out_tractogram, positions_csv=False,
             raise IOError('To use this script, you need at least 2'
                           'streamlines.')
 
-        with open(os.path.join(tmpdirname, "header.json"), "w") as out_json:
+        with open(os.path.join(tmp_dir_name, "header.json"), "w") as out_json:
             json.dump(header, out_json)
 
-        curr_filename = os.path.join(tmpdirname, 'positions.3.{}'.format(
+        curr_filename = os.path.join(tmp_dir_name, 'positions.3.{}'.format(
             positions_dtype))
         streamlines._data.astype(positions_dtype).tofile(
             curr_filename)
-        curr_filename = os.path.join(tmpdirname, 'offsets.{}'.format(
+        curr_filename = os.path.join(tmp_dir_name, 'offsets.{}'.format(
             offsets_dtype))
         streamlines._offsets.astype(offsets_dtype).tofile(
             curr_filename)
 
         if dpv:
-            os.mkdir(os.path.join(tmpdirname, 'dpv'))
+            os.mkdir(os.path.join(tmp_dir_name, 'dpv'))
             for arg in dpv:
                 curr_arr = np.squeeze(load_matrix_in_any_format(arg[0]).astype(
                     arg[1]))
@@ -383,12 +383,12 @@ def generate_trx_from_scratch(reference, out_tractogram, positions_csv=False,
                     raise IOError('Maximum of 2 dimensions for dpv/dps/dpg.')
                 dim = '' if curr_arr.ndim == 1 else '{}.'.format(
                     curr_arr.shape[-1])
-                curr_filename = os.path.join(tmpdirname, 'dpv', '{}.{}{}'.format(
+                curr_filename = os.path.join(tmp_dir_name, 'dpv', '{}.{}{}'.format(
                     os.path.basename(os.path.splitext(arg[0])[0]), dim, arg[1]))
                 curr_arr.tofile(curr_filename)
 
         if dps:
-            os.mkdir(os.path.join(tmpdirname, 'dps'))
+            os.mkdir(os.path.join(tmp_dir_name, 'dps'))
             for arg in dps:
                 curr_arr = np.squeeze(load_matrix_in_any_format(arg[0]).astype(
                     arg[1]))
@@ -398,12 +398,12 @@ def generate_trx_from_scratch(reference, out_tractogram, positions_csv=False,
                     raise IOError('Maximum of 2 dimensions for dpv/dps/dpg.')
                 dim = '' if curr_arr.ndim == 1 else '{}.'.format(
                     curr_arr.shape[-1])
-                curr_filename = os.path.join(tmpdirname, 'dps', '{}.{}{}'.format(
+                curr_filename = os.path.join(tmp_dir_name, 'dps', '{}.{}{}'.format(
                     os.path.basename(os.path.splitext(arg[0])[0]), dim, arg[1]))
                 curr_arr.tofile(curr_filename)
 
         if groups:
-            os.mkdir(os.path.join(tmpdirname, 'groups'))
+            os.mkdir(os.path.join(tmp_dir_name, 'groups'))
             for arg in groups:
                 curr_arr = load_matrix_in_any_format(arg[0]).astype(arg[1])
                 if arg[1] == 'bool':
@@ -412,15 +412,15 @@ def generate_trx_from_scratch(reference, out_tractogram, positions_csv=False,
                     raise IOError('Maximum of 2 dimensions for dpv/dps/dpg.')
                 dim = '' if curr_arr.ndim == 1 else '{}.'.format(
                     curr_arr.shape[-1])
-                curr_filename = os.path.join(tmpdirname, 'groups', '{}.{}{}'.format(
+                curr_filename = os.path.join(tmp_dir_name, 'groups', '{}.{}{}'.format(
                     os.path.basename(os.path.splitext(arg[0])[0]), dim, arg[1]))
                 curr_arr.tofile(curr_filename)
 
         if dpg:
-            os.mkdir(os.path.join(tmpdirname, 'dpg'))
+            os.mkdir(os.path.join(tmp_dir_name, 'dpg'))
             for arg in dpg:
-                if not os.path.isdir(os.path.join(tmpdirname, 'dpg', arg[0])):
-                    os.mkdir(os.path.join(tmpdirname, 'dpg', arg[0]))
+                if not os.path.isdir(os.path.join(tmp_dir_name, 'dpg', arg[0])):
+                    os.mkdir(os.path.join(tmp_dir_name, 'dpg', arg[0]))
                 curr_arr = load_matrix_in_any_format(arg[1]).astype(arg[2])
                 if arg[1] == 'bool':
                     arg[1] = 'bit'
@@ -430,11 +430,11 @@ def generate_trx_from_scratch(reference, out_tractogram, positions_csv=False,
                     curr_arr = curr_arr.reshape((1,))
                 dim = '' if curr_arr.ndim == 1 else '{}.'.format(
                     curr_arr.shape[-1])
-                curr_filename = os.path.join(tmpdirname, 'dpg', arg[0], '{}.{}{}'.format(
+                curr_filename = os.path.join(tmp_dir_name, 'dpg', arg[0], '{}.{}{}'.format(
                     os.path.basename(os.path.splitext(arg[1])[0]), dim, arg[2]))
                 curr_arr.tofile(curr_filename)
 
-        trx = tmm.load(tmpdirname)
+        trx = tmm.load(tmp_dir_name)
         tmm.save(trx, out_tractogram)
         trx.close()
 

--- a/trx/workflows.py
+++ b/trx/workflows.py
@@ -18,7 +18,7 @@ try:
 except ImportError:
     dipy_available = False
 
-from trx.io import get_trx_tmpdir, load, load_sft_with_reference, save
+from trx.io import get_trx_tmp_dir, load, load_sft_with_reference, save
 from trx.streamlines_ops import perform_streamlines_operation, intersection
 import trx.trx_file_memmap as tmm
 from trx.viz import display
@@ -311,7 +311,7 @@ def generate_trx_from_scratch(reference, out_tractogram, positions_csv=False,
                               space_str='rasmm', origin_str='nifti',
                               verify_invalid=True, dpv=[], dps=[],
                               groups=[], dpg=[]):
-    with get_trx_tmpdir() as tmpdirname:
+    with get_trx_tmp_dir() as tmpdirname:
         if positions_csv:
             with open(positions_csv, newline='') as f:
                 reader = csv.reader(f)


### PR DESCRIPTION
This was absent from trx testing, now: loading trx, to_sft(), save sft (trk/tck/vtk), close trx, save sft again and make sure this is working as intended.

I think that's the final one, version 0.2.7 will be the final one?