### PR TITLE
Move setuptools_scm to be a setup requirement, instead of installation.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,8 +25,8 @@ python_requires = >=3.8
 setup_requires =
     packaging >= 19.0
     cython >= 0.29
-install_requires =
     setuptools_scm
+install_requires =
     deepdiff
     nibabel >= 5
     numpy >= 1.22


### PR DESCRIPTION
Closes #73.