### PR TITLE
tff_generate_trx_from_scratch.py: fix typo.

### DIFF
--- a/scripts/tff_generate_trx_from_scratch.py
+++ b/scripts/tff_generate_trx_from_scratch.py
@@ -3,7 +3,7 @@
 
 """
 Generate TRX file from a collection of CSV, TXT or NPY files by individually
-specifiying positions, offsets, data_per_vertex, data_per_streamlines,
+specifying positions, offsets, data_per_vertex, data_per_streamlines,
 groups and data_per_group. Each file must have its data type specified by the
 users.
 


### PR DESCRIPTION
It was caught by lintian, the Debian linter, while working on the packaging of trx-python.