### PR TITLE
Fix shebangs and file mode

### DIFF
--- a/trx/fetcher.py
+++ b/trx/fetcher.py
@@ -1,4 +1,3 @@
-#! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import hashlib

--- a/trx/io.py
+++ b/trx/io.py
@@ -1,4 +1,3 @@
-#! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import os

--- a/trx/streamlines_ops.py
+++ b/trx/streamlines_ops.py
@@ -1,4 +1,3 @@
-#! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import itertools

--- a/trx/tests/test_io.py
+++ b/trx/tests/test_io.py
@@ -1,4 +1,3 @@
-#! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 from copy import deepcopy

--- a/trx/tests/test_memmap.py
+++ b/trx/tests/test_memmap.py
@@ -1,4 +1,3 @@
-#! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import os

--- a/trx/tests/test_streamlines_ops.py
+++ b/trx/tests/test_streamlines_ops.py
@@ -1,4 +1,3 @@
-#! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import numpy as np

--- a/trx/trx_file_memmap.py
+++ b/trx/trx_file_memmap.py
@@ -1,4 +1,3 @@
-#! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 from copy import deepcopy

--- a/trx/utils.py
+++ b/trx/utils.py
@@ -1,4 +1,3 @@
-#! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 from nibabel.streamlines.tractogram import TractogramItem

--- a/trx/viz.py
+++ b/trx/viz.py
@@ -1,4 +1,3 @@
-#! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import itertools

--- a/trx/workflows.py
+++ b/trx/workflows.py
@@ -1,4 +1,3 @@
-#! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 from copy import deepcopy


### PR DESCRIPTION
The module files are not stand alone scripts. Therefore the shebang is
unjustified as well as the executable bit.
