### PR TITLE
Update minimum setuptools_scm to version 7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 42.0", "wheel", "setuptools_scm[toml] >= 3.4", "setuptools_scm_git_archive"]
+requires = ["setuptools >= 42.0", "wheel", "setuptools_scm[toml] >= 7"]
 build-backend = "setuptools.build_meta:__legacy__"
 
 [tool.setuptools_scm]


### PR DESCRIPTION
Drop the `setuptools_scm_git_archive` dependency, now obsolete.

See: https://bugzilla.redhat.com/show_bug.cgi?id=2240107