### PR TITLE
Bug when building the zipfile using CLIs (zip, jar, etc)

### DIFF
--- a/scripts/tests/test_workflows.py
+++ b/scripts/tests/test_workflows.py
@@ -29,17 +29,17 @@ fetch_data(get_testing_files_dict(), keys=['DSI.zip', 'trx_from_scratch.zip'])
 
 
 def test_help_option_convert_dsi(script_runner):
-    ret = script_runner.run(['tff_convert_dsi_studio.py', '--help'])
+    ret = script_runner.run('tff_convert_dsi_studio.py', '--help')
     assert ret.success
 
 
 def test_help_option_convert(script_runner):
-    ret = script_runner.run(['tff_convert_tractogram.py', '--help'])
+    ret = script_runner.run('tff_convert_tractogram.py', '--help')
     assert ret.success
 
 
 def test_help_option_generate_trx_from_scratch(script_runner):
-    ret = script_runner.run(['tff_generate_trx_from_scratch.py', '--help'])
+    ret = script_runner.run('tff_generate_trx_from_scratch.py', '--help')
     assert ret.success
 
 

--- a/trx/trx_file_memmap.py
+++ b/trx/trx_file_memmap.py
@@ -233,7 +233,7 @@ def load(input_obj: str, check_dpg: bool = True) -> Type["TrxFile"]:
                 trx = load_from_directory(tmp_dir.name)
                 trx._uncompressed_folder_handle = tmp_dir
                 logging.info(
-                    "File was compressed, call the close() function before"
+                    "File was compressed, call the close() function before "
                     "exiting."
                 )
         else:
@@ -293,7 +293,7 @@ def load_from_zip(filename: str) -> Type["TrxFile"]:
             size = zip_info.file_size / dtype_size
 
             if len(zip_info.extra):
-                mem_adress += 4
+                mem_adress -= len(zip_info.extra)
 
             if size.is_integer():
                 files_pointer_size[elem_filename] = mem_adress, int(size)


### PR DESCRIPTION
Headers are slightly different and that was causing a shift in the data that could the positions (most common and visible problem) invalid (very high value both in positive or negative)