### PR TITLE
MNT: Fix OS matrix values in optional dependency job in CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,10 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: &os-matrix
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
     steps:
       - uses: actions/checkout@v5
         with:
@@ -40,8 +43,12 @@ jobs:
         run: spin test
 
   test-optional-deps:
-    name: Optional deps
+    name: Optional deps • Python ${{ matrix.python-version }} • ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python-version: ["3.12"]
+        os: *os-matrix
     steps:
       - uses: actions/checkout@v5
         with:
@@ -50,7 +57,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
           cache: pip
           cache-dependency-path: pyproject.toml
 


### PR DESCRIPTION
Fix OS matrix values in optional dependency job in CI workflow: use the appropriate syntax to store the values of the OS platforms in the `os.matrix` variable. In the current implementation, the variable is empty for the optional dependency job.

Fixes:
```
Error when evaluating 'runs-on' for job 'test-optional-deps'.
.github/workflows/test.yml (Line: 44, Col: 14): Unexpected value ''
```

visible for example in:
https://github.com/tee-ar-ex/trx-python/actions/runs/31546085298