### PR TITLE
STY: Remove unnecessary parentheses in test parameterization args

### DIFF
--- a/trx/tests/test_io.py
+++ b/trx/tests/test_io.py
@@ -25,7 +25,7 @@ from trx.trx_file_memmap import TrxFile
 fetch_data(get_testing_files_dict(), keys=["gold_standard.zip"])
 
 
-@pytest.mark.parametrize("path", [("gs.trk"), ("gs.tck"), ("gs.vtk")])
+@pytest.mark.parametrize("path", ["gs.trk", "gs.tck", "gs.vtk"])
 @pytest.mark.skipif(not dipy_available, reason="Dipy is not installed.")
 def test_seq_ops_sft(path):
     with TemporaryDirectory() as tmp_dir:
@@ -53,7 +53,7 @@ def test_seq_ops_trx():
         trx_2.close()
 
 
-@pytest.mark.parametrize("path", [("gs.trx"), ("gs.trk"), ("gs.tck"), ("gs.vtk")])
+@pytest.mark.parametrize("path", ["gs.trx", "gs.trk", "gs.tck", "gs.vtk"])
 @pytest.mark.skipif(not dipy_available, reason="Dipy is not installed.")
 def test_load_vox(path):
     from dipy.io.stateful_tractogram import Space
@@ -72,7 +72,7 @@ def test_load_vox(path):
         obj.close()
 
 
-@pytest.mark.parametrize("path", [("gs.trx"), ("gs.trk"), ("gs.tck"), ("gs.vtk")])
+@pytest.mark.parametrize("path", ["gs.trx", "gs.trk", "gs.tck", "gs.vtk"])
 @pytest.mark.skipif(not dipy_available, reason="Dipy is not installed.")
 def test_load_voxmm(path):
     from dipy.io.stateful_tractogram import Space
@@ -91,7 +91,7 @@ def test_load_voxmm(path):
         obj.close()
 
 
-@pytest.mark.parametrize("path", [("gs.trk"), ("gs.trx"), ("gs_fldr.trx")])
+@pytest.mark.parametrize("path", ["gs.trk", "gs.trx", "gs_fldr.trx"])
 @pytest.mark.skipif(not dipy_available, reason="Dipy is not installed.")
 def test_multi_load_save_rasmm(path):
     with TemporaryDirectory() as tmp_gs_dir:
@@ -117,7 +117,7 @@ def test_multi_load_save_rasmm(path):
             obj.close()
 
 
-@pytest.mark.parametrize("path", [("gs.trx"), ("gs_fldr.trx")])
+@pytest.mark.parametrize("path", ["gs.trx", "gs_fldr.trx"])
 @pytest.mark.skipif(not dipy_available, reason="Dipy is not installed.")
 def test_delete_tmp_gs_dir(path):
     gs_dir = os.path.join(get_home(), "gold_standard")
@@ -158,7 +158,7 @@ def test_delete_tmp_gs_dir(path):
     trx3.close()
 
 
-@pytest.mark.parametrize("path", [("gs.trx")])
+@pytest.mark.parametrize("path", ["gs.trx"])
 @pytest.mark.skipif(not dipy_available, reason="Dipy is not installed.")
 def test_close_tmp_files(path):
     gs_dir = os.path.join(get_home(), "gold_standard")
@@ -196,7 +196,7 @@ def test_close_tmp_files(path):
     assert not count
 
 
-@pytest.mark.parametrize("tmp_path", [("~"), ("use_working_dir")])
+@pytest.mark.parametrize("tmp_path", ["~", "use_working_dir"])
 def test_change_tmp_dir(tmp_path):
     gs_dir = os.path.join(get_home(), "gold_standard")
     path = os.path.join(gs_dir, "gs.trx")
@@ -218,7 +218,7 @@ def test_change_tmp_dir(tmp_path):
     assert not os.path.isdir(tmp_gs_dir)
 
 
-@pytest.mark.parametrize("path", [("gs.trx"), ("gs_fldr.trx")])
+@pytest.mark.parametrize("path", ["gs.trx", "gs_fldr.trx"])
 def test_complete_dir_from_trx(path):
     gs_dir = os.path.join(get_home(), "gold_standard")
     path = os.path.join(gs_dir, path)

--- a/trx/tests/test_memmap.py
+++ b/trx/tests/test_memmap.py
@@ -167,19 +167,19 @@ def test_load(path, check_dpg, value_error):
         assert isinstance(tmm.load(input_obj=path, check_dpg=check_dpg), tmm.TrxFile)
 
 
-@pytest.mark.parametrize("path", [("small.trx")])
+@pytest.mark.parametrize("path", ["small.trx"])
 def test_load_zip(path):
     path = os.path.join(get_home(), "memmap_test_data", path)
     assert isinstance(tmm.load_from_zip(path), tmm.TrxFile)
 
 
-@pytest.mark.parametrize("path", [("small_fldr.trx")])
+@pytest.mark.parametrize("path", ["small_fldr.trx"])
 def test_load_directory(path):
     path = os.path.join(get_home(), "memmap_test_data", path)
     assert isinstance(tmm.load_from_directory(path), tmm.TrxFile)
 
 
-@pytest.mark.parametrize("path", [("small.trx")])
+@pytest.mark.parametrize("path", ["small.trx"])
 def test_concatenate(path):
     path = os.path.join(get_home(), "memmap_test_data", path)
     trx1 = tmm.load(path)
@@ -192,7 +192,7 @@ def test_concatenate(path):
     concat.close()
 
 
-@pytest.mark.parametrize("path", [("small.trx")])
+@pytest.mark.parametrize("path", ["small.trx"])
 def test_resize(path):
     path = os.path.join(get_home(), "memmap_test_data", path)
     trx1 = tmm.load(path)
@@ -423,7 +423,7 @@ def test_trxfile_close():
     pass
 
 
-@pytest.mark.parametrize("path", [("small.trx")])
+@pytest.mark.parametrize("path", ["small.trx"])
 def test_close_releases_mmap_from_zip(path):
     """close() must release mmap handles even when loaded via load_from_zip()."""
     path = os.path.join(get_home(), "memmap_test_data", path)


### PR DESCRIPTION
Remove unnecessary parentheses around single-argument cases in test parameterizations.

Fixes:
```
Remove redundant parentheses
```

raised locally by IDE.

Reduces visual clutter, makes the code lighter and improves readability.