### PR TITLE
STYE: Avoid shadowing symbols from outer scope

### DIFF
--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -213,12 +213,12 @@ def lint(fix):
     default=False,
     help="Open documentation in browser after building",
 )
-def docs(clean, open_browser):
+def docs(_clean, open_browser):
     """Build documentation using Sphinx.
 
     Parameters
     ----------
-    clean : bool
+    _clean : bool
         If True, clean build directory before building.
     open_browser : bool
         If True, open documentation in browser after building.
@@ -227,7 +227,7 @@ def docs(clean, open_browser):
 
     docs_dir = "docs"
 
-    if clean:
+    if _clean:
         click.echo("Cleaning build directory...")
         build_dir = os.path.join(docs_dir, "_build")
         if os.path.exists(build_dir):

--- a/trx/cli.py
+++ b/trx/cli.py
@@ -993,8 +993,8 @@ def info(
     typer.echo(f"Size: {_format_size(file_size)}")
 
     with zipfile.ZipFile(str(in_tractogram), "r") as zf:
-        total_uncompressed = sum(info.file_size for info in zf.infolist())
-        is_compressed = any(info.compress_type != 0 for info in zf.infolist())
+        total_uncompressed = sum(_info.file_size for _info in zf.infolist())
+        is_compressed = any(_info.compress_type != 0 for _info in zf.infolist())
         typer.echo(f"Entries: {len(zf.infolist())}")
         typer.echo(f"Compressed: {'Yes' if is_compressed else 'No'}")
         typer.echo(f"Uncompressed size: {_format_size(total_uncompressed)}")


### PR DESCRIPTION
Rename variable names/parameters to avoid shadowing symbols from outer scope.

Fixes:
```
Shadows name 'info' from outer scope
```

and
```
Shadows name 'clean' from outer scope
```

raised locally by IDE.