### PR TITLE
CI: point workflows and docs at main after the branch rename

### DIFF
--- a/.github/workflows/codeformat.yml
+++ b/.github/workflows/codeformat.yml
@@ -2,9 +2,9 @@ name: Code Format
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 permissions:
   contents: read

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,9 +2,9 @@ name: Coverage
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 permissions:
   contents: read

--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -2,11 +2,11 @@ name: Documentation build
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
     tags:
       - '*'
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
   workflow_dispatch:
 
 permissions:
@@ -46,7 +46,7 @@ jobs:
   deploy-dev:
     needs: build
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'tee-ar-ex/trx-python'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'tee-ar-ex/trx-python'
     steps:
     - uses: actions/checkout@v5
     - uses: actions/download-artifact@v4

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -3,7 +3,7 @@ name: Publish to TestPyPI and PyPI
 on:
   push:
     branches:
-      - master
+      - main
     tags:
       - "*"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Tests
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 permissions:
   contents: read

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Tests](https://github.com/tee-ar-ex/trx-python/actions/workflows/test.yml/badge.svg)](https://github.com/tee-ar-ex/trx-python/actions/workflows/test.yml)
 [![Code Format](https://github.com/tee-ar-ex/trx-python/actions/workflows/codeformat.yml/badge.svg)](https://github.com/tee-ar-ex/trx-python/actions/workflows/codeformat.yml)
-[![codecov](https://codecov.io/gh/tee-ar-ex/trx-python/branch/master/graph/badge.svg)](https://codecov.io/gh/tee-ar-ex/trx-python)
+[![codecov](https://codecov.io/gh/tee-ar-ex/trx-python/branch/main/graph/badge.svg)](https://codecov.io/gh/tee-ar-ex/trx-python)
 [![PyPI version](https://badge.fury.io/py/trx-python.svg)](https://badge.fury.io/py/trx-python)
 
 A Python implementation of the TRX file format for tractography data.

--- a/docs/source/contributing.md
+++ b/docs/source/contributing.md
@@ -91,7 +91,7 @@ spin docs       # Build documentation
    git push origin my-feature-branch
    ```
 
-2. **Open a Pull Request** on GitHub against the `master` branch
+2. **Open a Pull Request** on GitHub against the `main` branch
 
 3. **Describe your changes** in the PR description:
 


### PR DESCRIPTION
The default branch was renamed from master to main, but every workflow still triggered on master. Since that branch no longer exists, pushes to main fired nothing: no tests, no coverage, no format checks, no docs.

docbuild.yml also gated the dev-docs deploy on
`github.ref == 'refs/heads/master'`, so /dev/ had silently stopped updating on merge.

Also update the two stale branch references in prose: the codecov badge URL in README.md and the target branch named in the contributing guide.